### PR TITLE
Add create-tables and improve restore process

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -23,15 +23,19 @@ COMMANDS:
      freeze          Freeze all or specific tables. You may use this syntax for specify tables [db].[table]
      upload          Upload 'metadata' and 'shadows' directories to s3. Extra files on s3 will be deleted
      download        Download 'metadata' and 'shadows' from s3 to backup folder. Pass filename for archive strategy
-     create-tables   NOT IMPLEMENTED! Create tables from backup metadata
-     restore         Copy data from 'backup' to 'detached' folder and execute ATTACH. You can specify tables [db].[table] and increments via -i flag
+     create-tables   Create databases and tables from backup metadata
+     restore         Copy data from 'backup' to 'detached' folder and execute ATTACH.
+                     You can specify tables [db].[table] and increments via -i flag. -d flag
+                     to use legacy partitioning key.
      default-config  Print default config and exit
      clean           Remove contents from 'shadow' directory
      help, h         Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
    --config FILE, -c FILE  Config FILE name. (default: "/etc/clickhouse-backup/config.yml")
-   --dry-run               Only show what should be uploaded or downloaded but don't actually do it. May still perform S3 requests to get bucket listings and other information though (only for file transfer commands)
+   --dry-run               Only show what should be uploaded or downloaded but don't actually do it. 
+                           May still perform S3 requests to get bucket listings and other information
+                           though (only for file transfer commands)
    --help, -h              show help
    --version, -v           print the version
 ```
@@ -59,6 +63,7 @@ s3:
   # "skip" - the fastest but can make backup inconsistently
   # "etag" - calculate etag for local files, set this if your network is very slow
   overwrite_strategy: "always"
+  part_size: 5242880
 backup:
   strategy: tree
   backups_to_keep: 10

--- a/archive.go
+++ b/archive.go
@@ -12,6 +12,7 @@ import (
 	"time"
 )
 
+// TarDirs - add bunch of directories to tarball
 func TarDirs(w io.Writer, dirs ...string) error {
 	tw := tarArchive.NewWriter(w)
 	defer tw.Close()
@@ -23,6 +24,7 @@ func TarDirs(w io.Writer, dirs ...string) error {
 	return nil
 }
 
+// TarDir - add directory to tarball
 func TarDir(tw *tarArchive.Writer, dir string) error {
 	return tarDir(tw, dir)
 }
@@ -114,6 +116,7 @@ func tarDir(tw *tarArchive.Writer, dir string) (err error) {
 	return nil
 }
 
+// Untar - extract contents of tarball to specified destination
 func Untar(r io.Reader, dir string) (err error) {
 	t0 := time.Now()
 	nFiles := 0

--- a/archive.go
+++ b/archive.go
@@ -77,7 +77,7 @@ func tarDir(tw *tarArchive.Writer, dir string) (err error) {
 
 		st := fi.Sys().(*syscall.Stat_t)
 		di := devino{
-			Dev: st.Dev,
+			Dev: uint64(st.Dev),
 			Ino: st.Ino,
 		}
 		orig, ok := seen[di]
@@ -113,7 +113,6 @@ func tarDir(tw *tarArchive.Writer, dir string) (err error) {
 
 		return nil
 	})
-	return nil
 }
 
 // Untar - extract contents of tarball to specified destination

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -24,7 +24,7 @@ type ClickHouse struct {
 	gid    *int
 }
 
-// Table - table struct
+// Table - Clickhouse table struct
 type Table struct {
 	Database     string `db:"database"`
 	Name         string `db:"name"`
@@ -33,13 +33,13 @@ type Table struct {
 	IsTemporary  bool   `db:"is_temporary"`
 }
 
-// BackupPartition -
+// BackupPartition - struct representing Clickhouse partition
 type BackupPartition struct {
 	Name string
 	Path string
 }
 
-// BackupTable -
+// BackupTable - struct to store additional information on partitions
 type BackupTable struct {
 	Increment  int
 	Database   string
@@ -90,7 +90,7 @@ func (ch *ClickHouse) GetTables() ([]Table, error) {
 	return tables, nil
 }
 
-// FreezeTable - freze all partitions for table
+// FreezeTable - freeze all partitions for table
 func (ch *ClickHouse) FreezeTable(table Table) error {
 	var partitions []struct {
 		PartitionID string `db:"partition_id"`
@@ -102,7 +102,7 @@ func (ch *ClickHouse) FreezeTable(table Table) error {
 	log.Printf("Freeze '%v.%v'", table.Database, table.Name)
 	for _, item := range partitions {
 		if ch.DryRun {
-			log.Printf("  partition '%v'   ...skip becouse dry-run", item.PartitionID)
+			log.Printf("  partition '%v'   ...skip because dry-run", item.PartitionID)
 			continue
 		}
 		log.Printf("  partition '%v'", item.PartitionID)
@@ -126,13 +126,13 @@ func (ch *ClickHouse) FreezeTable(table Table) error {
 				table.Name,
 				item.PartitionID,
 			)); err != nil {
-			return fmt.Errorf("can't freze partiotion '%s' on '%s.%s' with: %v", item.PartitionID, table.Database, table.Name, err)
+			return fmt.Errorf("can't freeze partition '%s' on '%s.%s' with: %v", item.PartitionID, table.Database, table.Name, err)
 		}
 	}
 	return nil
 }
 
-// GetBackupTables - returns list of backups of tables can be restored
+// GetBackupTables - return list of backups of tables that can be restored
 func (ch *ClickHouse) GetBackupTables() (map[string]BackupTable, error) {
 	dataPath, err := ch.GetDataPath()
 	if err != nil {
@@ -207,10 +207,10 @@ func (ch *ClickHouse) Chown(name string) error {
 // CopyData - copy partitions for specific table to detached folder
 func (ch *ClickHouse) CopyData(table BackupTable) error {
 	if ch.DryRun {
-		log.Printf("copy %s.%s inscrement %d  ...scip dry-run", table.Database, table.Name, table.Increment)
+		log.Printf("copy %s.%s increment %d  ...skip dry-run", table.Database, table.Name, table.Increment)
 		return nil
 	}
-	log.Printf("copy %s.%s inscrement %d", table.Database, table.Name, table.Increment)
+	log.Printf("copy %s.%s increment %d", table.Database, table.Name, table.Increment)
 	dataPath, err := ch.GetDataPath()
 	if err != nil {
 		return err
@@ -223,13 +223,13 @@ func (ch *ClickHouse) CopyData(table BackupTable) error {
 				return fmt.Errorf("%v", err)
 			}
 		} else if !info.IsDir() {
-			return fmt.Errorf("'%s' must be not exists", detachedPath)
+			return fmt.Errorf("'%s' should not exist", detachedPath)
 		}
 		if err := filepath.Walk(partition.Path, func(filePath string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err
 			}
-			filePath = filepath.ToSlash(filePath) // fix fucking Windows slashes
+			filePath = filepath.ToSlash(filePath) // fix Windows slashes
 			srcFileStat, err := os.Stat(filePath)
 			if err != nil {
 				return err

--- a/config.go
+++ b/config.go
@@ -28,6 +28,7 @@ type S3Config struct {
 	DisableSSL         bool   `yaml:"disable_ssl"`
 	DisableProgressBar bool   `yaml:"disable_progress_bar"`
 	OverwriteStrategy  string `yaml:"overwrite_strategy"`
+	PartSize           int64  `yaml:"part_size"`
 }
 
 // ClickHouseConfig - clickhouse settings section
@@ -95,6 +96,7 @@ func defaultConfig() *Config {
 			DisableSSL:        false,
 			ACL:               "private",
 			OverwriteStrategy: "always",
+			PartSize:          5 * 1024 * 1024,
 		},
 		Backup: BackupConfig{
 			Strategy:      "tree",

--- a/main.go
+++ b/main.go
@@ -245,7 +245,7 @@ func restore(config Config, args []string, dryRun bool, increments []int, deprec
 		return err
 	}
 	if len(restoreTables) == 0 {
-		return fmt.Errorf("no have tables for restore")
+		return fmt.Errorf("didn't find tables to restore")
 	}
 	for _, table := range restoreTables {
 		// TODO: Use move instead copy

--- a/main.go
+++ b/main.go
@@ -2,13 +2,15 @@ package main
 
 import (
 	"fmt"
-	"github.com/urfave/cli"
 	"io/ioutil"
 	"log"
 	"os"
 	"path"
 	"path/filepath"
 	"sort"
+	"strings"
+
+	"github.com/urfave/cli"
 )
 
 var config *Config
@@ -83,9 +85,9 @@ func main() {
 		},
 		{
 			Name:  "create-tables",
-			Usage: "NOT IMPLEMENTED! Create tables from backup metadata",
+			Usage: "Create databases and tables from backup metadata",
 			Action: func(c *cli.Context) error {
-				return fmt.Errorf("NOT IMPLEMENTED!")
+				return createTables(*config, c.Args(), c.Bool("dry-run") || c.GlobalBool("dry-run"))
 			},
 			Flags: cliapp.Flags,
 		},
@@ -193,6 +195,97 @@ func getTables(config Config, args []string) error {
 	for _, table := range allTables {
 		fmt.Printf("%s.%s\n", table.Database, table.Name)
 	}
+	return nil
+}
+
+func createTables(config Config, args []string, dryRun bool) error {
+	ch := &ClickHouse{
+		DryRun: dryRun,
+		Config: &config.ClickHouse,
+	}
+
+	if err := ch.Connect(); err != nil {
+		return fmt.Errorf("can't connect to clickouse with: %v", err)
+	}
+	defer ch.Close()
+
+	dataPath := config.ClickHouse.DataPath
+	if dataPath == "" {
+		if err := ch.Connect(); err != nil {
+			return fmt.Errorf("can't connect to clickhouse for get data path with: %v\nyou can set clickhouse.data_path in config", err)
+		}
+		defer ch.Close()
+		var err error
+		if dataPath, err = ch.GetDataPath(); err != nil || dataPath == "" {
+			return fmt.Errorf("can't get data path from clickhouse with: %v\nyou can set data_path in config file", err)
+		}
+	}
+	log.Printf("Found clickhouse data path: %s", dataPath)
+
+	metadataPath := path.Join(dataPath, "backup", "metadata")
+	log.Printf("Will analyze restored metadata from here: %s", metadataPath)
+
+	// for each dir in metadataPath (database name)
+	// except system execute scripts
+	files, err := ioutil.ReadDir(metadataPath)
+	if err != nil {
+		return fmt.Errorf("can't read metadata directory for creating tables: %v", err)
+	}
+
+	var distributedTables []RestoreTable
+	for _, file := range files {
+		if file.IsDir() {
+			databaseName := file.Name()
+			if databaseName == "system" {
+				// do not touch system database
+				continue
+			}
+			log.Printf("Found metadata files for database: %s", databaseName)
+			ch.CreateDatabase(databaseName)
+			databaseDir := path.Join(metadataPath, databaseName)
+			log.Printf("Will analyze table information from here: %s", databaseDir)
+			tableFiles, err := ioutil.ReadDir(databaseDir)
+			if err != nil {
+				return fmt.Errorf("can't read database directory in metadata dir: %v", err)
+			}
+			for _, table := range tableFiles {
+				if strings.HasSuffix(table.Name(), "sql") {
+					tablePath := path.Join(databaseDir, table.Name())
+					log.Printf("Found table: %s", tablePath)
+					dat, err := ioutil.ReadFile(tablePath)
+					if err != nil {
+						return fmt.Errorf("can't read file %s: %v", tablePath, err)
+					}
+					tableCreateQuery := strings.Replace(string(dat), "ATTACH", "CREATE", 1)
+
+					if strings.Contains(tableCreateQuery, "ENGINE = Distributed") {
+						// distributed engine tables should be created last
+						// because they are based on real tables
+						log.Printf("this is a distributed table, saving for later")
+						distributedTables = append(distributedTables, RestoreTable{
+							Database: databaseName,
+							Query:    tableCreateQuery,
+						})
+					} else {
+						err := ch.CreateTable(RestoreTable{
+							Database: databaseName,
+							Query:    tableCreateQuery,
+						})
+						if err != nil {
+							return err
+						}
+					}
+				}
+			}
+		}
+	}
+	log.Printf("creating distributed tables...")
+	for _, table := range distributedTables {
+		if err := ch.CreateTable(table); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/s3.go
+++ b/s3.go
@@ -45,7 +45,7 @@ func (s *S3) Connect() (err error) {
 	return
 }
 
-// Upload - synchronize localPath to dstPath on s3
+// UploadDirectory - synchronize localPath to dstPath on s3
 func (s *S3) UploadDirectory(localPath string, dstPath string) error {
 	// TODO: it must be refactored like as Download() method
 	iter, filesForDelete, err := s.newSyncFolderIterator(localPath, dstPath)
@@ -114,7 +114,7 @@ func (s *S3) UploadDirectory(localPath string, dstPath string) error {
 	return nil
 }
 
-// Upload - synchronize localPath to dstPath on s3
+// UploadFile - synchronize localPath to dstPath on s3
 func (s *S3) UploadFile(localPath string, dstPath string) error {
 
 	uploader := s3manager.NewUploader(s.session)
@@ -139,7 +139,7 @@ func (s *S3) UploadFile(localPath string, dstPath string) error {
 	return nil
 }
 
-// Download - download files from s3Path to localPath
+// DownloadTree - download files from s3Path to localPath
 func (s *S3) DownloadTree(s3Path string, localPath string) error {
 	if err := os.MkdirAll(localPath, 0755); err != nil {
 		return fmt.Errorf("can't create '%s' with: %v", localPath, err)
@@ -198,7 +198,7 @@ func (s *S3) DownloadTree(s3Path string, localPath string) error {
 	return nil
 }
 
-// Download - download files from s3Path to localPath
+// DownloadArchive - download files from s3Path to localPath
 func (s *S3) DownloadArchive(s3Path string, localPath string) error {
 	if err := os.MkdirAll(localPath, 0755); err != nil {
 		return fmt.Errorf("can't create '%s' with: %v", localPath, err)
@@ -438,7 +438,7 @@ func (s *S3) ListObjects(s3Path string) ([]*s3.Object, error) {
 	return resp.Contents, nil
 }
 
-// ListObjects - get list of objects from s3
+// DeleteObjects - delete list of objects from s3
 func (s *S3) DeleteObjects(objects []*s3.Object) error {
 	batcher := s3manager.NewBatchDelete(s.session)
 	batchObjects := make([]s3manager.BatchDeleteObject, len(objects))

--- a/s3.go
+++ b/s3.go
@@ -19,11 +19,6 @@ import (
 	pb "gopkg.in/cheggaaa/pb.v1"
 )
 
-const (
-	// PART_SIZE - default s3 part size for calculing ETag
-	PART_SIZE = 5 * 1024 * 1024
-)
-
 // S3 - presents methods for manipulate data on s3
 type S3 struct {
 	session *session.Session
@@ -60,7 +55,7 @@ func (s *S3) UploadDirectory(localPath string, dstPath string) error {
 	}
 
 	uploader := s3manager.NewUploader(s.session)
-	uploader.PartSize = PART_SIZE
+	uploader.PartSize = config.S3.PartSize
 	var errs []s3manager.Error
 	for iter.Next() {
 		object := iter.UploadObject()
@@ -118,7 +113,7 @@ func (s *S3) UploadDirectory(localPath string, dstPath string) error {
 func (s *S3) UploadFile(localPath string, dstPath string) error {
 
 	uploader := s3manager.NewUploader(s.session)
-	uploader.PartSize = PART_SIZE
+	uploader.PartSize = config.S3.PartSize
 
 	file, err := os.Open(localPath)
 	if err != nil {
@@ -166,7 +161,7 @@ func (s *S3) DownloadTree(s3Path string, localPath string) error {
 				case "skip":
 					continue
 				case "etag":
-					if s3File.etag == GetEtag(existsFile.fullpath) {
+					if s3File.etag == GetEtag(existsFile.fullpath, s.Config.PartSize) {
 						continue
 					}
 				}
@@ -317,7 +312,7 @@ func (s *S3) newSyncFolderIterator(localPath, dstPath string) (*SyncFolderIterat
 						skipFilesCount++
 						return nil
 					case "etag":
-						if existFile.etag == GetEtag(filePath) {
+						if existFile.etag == GetEtag(filePath, s.Config.PartSize) {
 							// log.Printf("File '%s' already uploaded and has the same size and etag. Skip", key)
 							skipFilesCount++
 							return nil
@@ -399,27 +394,27 @@ func (iter *SyncFolderIterator) UploadObject() s3manager.BatchUploadObject {
 }
 
 // GetEtag - calculate ETag for file
-func GetEtag(path string) string {
+func GetEtag(path string, partSize int64) string {
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
 		return "unknown"
 	}
-	size := len(content)
-	if size <= PART_SIZE {
+	size := int64(len(content))
+	if size <= partSize {
 		hash := md5.Sum(content)
 		return fmt.Sprintf("\"%x\"", hash)
 	}
 	parts := 0
-	pos := 0
+	var pos int64
 	contentToHash := make([]byte, 0)
 	for size > pos {
-		endpos := pos + PART_SIZE
+		endpos := pos + partSize
 		if endpos >= size {
 			endpos = size
 		}
 		hash := md5.Sum(content[pos:endpos])
 		contentToHash = append(contentToHash, hash[:]...)
-		pos += PART_SIZE
+		pos += partSize
 		parts++
 	}
 	hash := md5.Sum(contentToHash)


### PR DESCRIPTION
- add create-tables command implementation

when restoring to fresh installation of Clickhouse a step to recreate databases and tables had to be done manually. now create-tables method takes metadata information stored with backup and recreates all objects including distributed tables (they are created last). tables should not exist before running this command.

- change convert partition method to support custom partitioning key

convertPartition was expecting one of two:
    - legacy partitioning key toYYYYMM(date_column)
    - partitioning key based on data YYYY-MM-DD

as cited in documentation https://clickhouse.yandex/docs/en/operations/table_engines/custom_partitioning_key/ name of partition same as in system.parts table can be used. this is also same as used in file name. this means just that part itself may be used in ATTACH PARTITION query.

- make partition size for S3 object configurable

there was a hard coded value equal to 5 MB. this is saved as default value, but now it may be changed via configuration file.

- add documentation comments and fix some comments. no code changes