### PR TITLE
Add create-tables and improve restore process

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -23,15 +23,19 @@ COMMANDS:
      freeze          Freeze all or specific tables. You may use this syntax for specify tables [db].[table]
      upload          Upload 'metadata' and 'shadows' directories to s3. Extra files on s3 will be deleted
      download        Download 'metadata' and 'shadows' from s3 to backup folder. Pass filename for archive strategy
-     create-tables   NOT IMPLEMENTED! Create tables from backup metadata
-     restore         Copy data from 'backup' to 'detached' folder and execute ATTACH. You can specify tables [db].[table] and increments via -i flag
+     create-tables   Create databases and tables from backup metadata
+     restore         Copy data from 'backup' to 'detached' folder and execute ATTACH.
+                     You can specify tables [db].[table] and increments via -i flag. -d flag
+                     to use legacy partitioning key. -m flag to move files instead of copy.
      default-config  Print default config and exit
      clean           Remove contents from 'shadow' directory
      help, h         Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
    --config FILE, -c FILE  Config FILE name. (default: "/etc/clickhouse-backup/config.yml")
-   --dry-run               Only show what should be uploaded or downloaded but don't actually do it. May still perform S3 requests to get bucket listings and other information though (only for file transfer commands)
+   --dry-run               Only show what should be uploaded or downloaded but don't actually do it. 
+                           May still perform S3 requests to get bucket listings and other information
+                           though (only for file transfer commands)
    --help, -h              show help
    --version, -v           print the version
 ```

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -61,5 +61,5 @@ s3:
   overwrite_strategy: "always"
 backup:
   strategy: tree
-  backups_to_keep: 10
+  backups_to_keep: 0
 ```

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -59,6 +59,7 @@ s3:
   # "skip" - the fastest but can make backup inconsistently
   # "etag" - calculate etag for local files, set this if your network is very slow
   overwrite_strategy: "always"
+  part_size: 5242880
 backup:
   strategy: tree
   backups_to_keep: 0

--- a/archive.go
+++ b/archive.go
@@ -12,6 +12,7 @@ import (
 	"time"
 )
 
+// TarDirs - add bunch of directories to tarball
 func TarDirs(w io.Writer, dirs ...string) error {
 	tw := tarArchive.NewWriter(w)
 	defer tw.Close()
@@ -23,6 +24,7 @@ func TarDirs(w io.Writer, dirs ...string) error {
 	return nil
 }
 
+// TarDir - add directory to tarball
 func TarDir(tw *tarArchive.Writer, dir string) error {
 	return tarDir(tw, dir)
 }
@@ -50,7 +52,7 @@ func tarDir(tw *tarArchive.Writer, dir string) (err error) {
 		return fmt.Errorf("unable to tar files - %v", err.Error())
 	}
 	if !fi.IsDir() {
-		return fmt.Errorf("data path is not a directory - %v", err.Error())
+		return fmt.Errorf("data path is not a directory - %s", dir)
 	}
 
 	seen := make(map[devino]string)

--- a/archive.go
+++ b/archive.go
@@ -103,33 +103,35 @@ func tarDir(tw *tarArchive.Writer, dir string) (err error) {
 		if err != nil {
 			return err
 		}
+		defer f.Close()
 
 		io.Copy(tw, f)
-
-		f.Close()
 
 		seen[di] = filename
 		nFiles++
 
 		return nil
 	})
-	return nil
 }
 
-func Untar(r io.Reader, dir string) (err error) {
+// Untar - extract contents of tarball to specified destination
+func Untar(r io.Reader, extractDir string) (err error) {
 	t0 := time.Now()
 	nFiles := 0
 	madeDir := map[string]bool{}
 	defer func() {
 		td := time.Since(t0)
 		if err == nil {
-			log.Printf("extracted tarball into %s: %d files, %d dirs (%v)", dir, nFiles, len(madeDir), td)
+			log.Printf("extracted tarball into %s: %d files, %d dirs (%v)", extractDir, nFiles, len(madeDir), td)
 		} else {
-			log.Printf("error extracting tarball into %s after %d files, %d dirs, %v: %v", dir, nFiles, len(madeDir), td, err)
+			log.Printf("error extracting tarball into %s after %d files, %d dirs, %v: %v", extractDir, nFiles, len(madeDir), td, err)
 		}
 	}()
 	tr := tarArchive.NewReader(r)
 	loggedChtimesError := false
+
+	seen := make(map[string]string)
+
 	for {
 		f, err := tr.Next()
 		if err == io.EOF {
@@ -142,8 +144,9 @@ func Untar(r io.Reader, dir string) (err error) {
 		if !validRelPath(f.Name) {
 			return fmt.Errorf("tar contained invalid name error %q", f.Name)
 		}
+
 		rel := filepath.FromSlash(f.Name)
-		abs := filepath.Join(dir, rel)
+		abs := filepath.Join(extractDir, rel)
 
 		fi := f.FileInfo()
 		mode := fi.Mode()
@@ -160,6 +163,13 @@ func Untar(r io.Reader, dir string) (err error) {
 				}
 				madeDir[dir] = true
 			}
+
+			if f.Size == 0 && f.Linkname != "" {
+				// this is a hard link for another file. save it and create at the end
+				seen[abs] = filepath.Join(extractDir, f.Linkname)
+				continue
+			}
+
 			wf, err := os.OpenFile(abs, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode.Perm())
 			if err != nil {
 				return err
@@ -201,6 +211,12 @@ func Untar(r io.Reader, dir string) (err error) {
 			madeDir[abs] = true
 		default:
 			return fmt.Errorf("tar file entry %s contained unsupported file type %v", f.Name, mode)
+		}
+	}
+
+	for abs, target := range seen {
+		if err := os.Link(target, abs); err != nil {
+			return fmt.Errorf("failed to create hard link from %s to %s: %v", abs, target, err)
 		}
 	}
 	return nil

--- a/config.go
+++ b/config.go
@@ -28,6 +28,7 @@ type S3Config struct {
 	DisableSSL         bool   `yaml:"disable_ssl"`
 	DisableProgressBar bool   `yaml:"disable_progress_bar"`
 	OverwriteStrategy  string `yaml:"overwrite_strategy"`
+	PartSize           int64  `yaml:"part_size"`
 }
 
 // ClickHouseConfig - clickhouse settings section
@@ -95,6 +96,7 @@ func defaultConfig() *Config {
 			DisableSSL:        false,
 			ACL:               "private",
 			OverwriteStrategy: "always",
+			PartSize:          5 * 1024 * 1024,
 		},
 		Backup: BackupConfig{
 			Strategy:      "tree",

--- a/config.go
+++ b/config.go
@@ -98,7 +98,7 @@ func defaultConfig() *Config {
 		},
 		Backup: BackupConfig{
 			Strategy:      "tree",
-			BackupsToKeep: 10,
+			BackupsToKeep: 0,
 		},
 	}
 }

--- a/config.yml
+++ b/config.yml
@@ -15,6 +15,8 @@ s3:
   path: ""
   disable_ssl: false
   disable_progress_bar: false
+  overwrite_strategy: always
+  part_size: 5242880
 backup:
   strategy: tree
   backups_to_keep: 0

--- a/config.yml
+++ b/config.yml
@@ -16,5 +16,5 @@ s3:
   disable_ssl: false
   disable_progress_bar: false
 backup:
-  strategy: "archive"
-  backups_to_keep: 10
+  strategy: tree
+  backups_to_keep: 0

--- a/main.go
+++ b/main.go
@@ -454,6 +454,10 @@ func cleanDir(dir string) error {
 }
 
 func removeOldBackups(config Config, s3 *S3) error {
+	if config.Backup.BackupsToKeep < 1 {
+		log.Printf("Cleaning old backups is not enabled.")
+		return nil
+	}
 	objects, err := s3.ListObjects(config.S3.Path)
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -245,7 +245,7 @@ func restore(config Config, args []string, dryRun bool, increments []int, deprec
 		return err
 	}
 	if len(restoreTables) == 0 {
-		return fmt.Errorf("no have tables for restore")
+		return fmt.Errorf("didn't find tables to restore")
 	}
 	for _, table := range restoreTables {
 		// TODO: Use move instead copy
@@ -403,7 +403,7 @@ func downloadArchive(s3 *S3, dataPath string, filename string) error {
 		return fmt.Errorf("error opening archive: %v", err)
 	}
 	if err := Untar(archiveFile, dstPath); err != nil {
-		return fmt.Errorf("error unarchiving %v", err)
+		return fmt.Errorf("error unarchiving: %v", err)
 	}
 	return nil
 }

--- a/s3.go
+++ b/s3.go
@@ -45,7 +45,7 @@ func (s *S3) Connect() (err error) {
 	return
 }
 
-// Upload - synchronize localPath to dstPath on s3
+// UploadDirectory - synchronize localPath to dstPath on s3
 func (s *S3) UploadDirectory(localPath string, dstPath string) error {
 	// TODO: it must be refactored like as Download() method
 	iter, filesForDelete, err := s.newSyncFolderIterator(localPath, dstPath)
@@ -114,7 +114,7 @@ func (s *S3) UploadDirectory(localPath string, dstPath string) error {
 	return nil
 }
 
-// Upload - synchronize localPath to dstPath on s3
+// UploadFile - synchronize localPath to dstPath on s3
 func (s *S3) UploadFile(localPath string, dstPath string) error {
 
 	uploader := s3manager.NewUploader(s.session)
@@ -139,7 +139,7 @@ func (s *S3) UploadFile(localPath string, dstPath string) error {
 	return nil
 }
 
-// Download - download files from s3Path to localPath
+// DownloadTree - download files from s3Path to localPath
 func (s *S3) DownloadTree(s3Path string, localPath string) error {
 	if err := os.MkdirAll(localPath, 0755); err != nil {
 		return fmt.Errorf("can't create '%s' with: %v", localPath, err)
@@ -198,7 +198,7 @@ func (s *S3) DownloadTree(s3Path string, localPath string) error {
 	return nil
 }
 
-// Download - download files from s3Path to localPath
+// DownloadArchive - download files from s3Path to localPath
 func (s *S3) DownloadArchive(s3Path string, localPath string) error {
 	if err := os.MkdirAll(localPath, 0755); err != nil {
 		return fmt.Errorf("can't create '%s' with: %v", localPath, err)
@@ -438,7 +438,7 @@ func (s *S3) ListObjects(s3Path string) ([]*s3.Object, error) {
 	return resp.Contents, nil
 }
 
-// ListObjects - get list of objects from s3
+// DeleteObjects - delete list of objects from s3
 func (s *S3) DeleteObjects(objects []*s3.Object) error {
 	batcher := s3manager.NewBatchDelete(s.session)
 	batchObjects := make([]s3manager.BatchDeleteObject, len(objects))

--- a/s3.go
+++ b/s3.go
@@ -19,11 +19,6 @@ import (
 	pb "gopkg.in/cheggaaa/pb.v1"
 )
 
-const (
-	// PART_SIZE - default s3 part size for calculing ETag
-	PART_SIZE = 5 * 1024 * 1024
-)
-
 // S3 - presents methods for manipulate data on s3
 type S3 struct {
 	session *session.Session
@@ -60,7 +55,7 @@ func (s *S3) UploadDirectory(localPath string, dstPath string) error {
 	}
 
 	uploader := s3manager.NewUploader(s.session)
-	uploader.PartSize = PART_SIZE
+	uploader.PartSize = config.S3.PartSize
 	var errs []s3manager.Error
 	for iter.Next() {
 		object := iter.UploadObject()
@@ -118,7 +113,7 @@ func (s *S3) UploadDirectory(localPath string, dstPath string) error {
 func (s *S3) UploadFile(localPath string, dstPath string) error {
 
 	uploader := s3manager.NewUploader(s.session)
-	uploader.PartSize = PART_SIZE
+	uploader.PartSize = config.S3.PartSize
 
 	file, err := os.Open(localPath)
 	if err != nil {
@@ -166,7 +161,7 @@ func (s *S3) DownloadTree(s3Path string, localPath string) error {
 				case "skip":
 					continue
 				case "etag":
-					if s3File.etag == GetEtag(existsFile.fullpath) {
+					if s3File.etag == GetEtag(existsFile.fullpath, s.Config.PartSize) {
 						continue
 					}
 				}
@@ -317,7 +312,7 @@ func (s *S3) newSyncFolderIterator(localPath, dstPath string) (*SyncFolderIterat
 						skipFilesCount++
 						return nil
 					case "etag":
-						if existFile.etag == GetEtag(filePath) {
+						if existFile.etag == GetEtag(filePath, s.Config.PartSize) {
 							// log.Printf("File '%s' already uploaded and has the same size and etag. Skip", key)
 							skipFilesCount++
 							return nil
@@ -399,27 +394,27 @@ func (iter *SyncFolderIterator) UploadObject() s3manager.BatchUploadObject {
 }
 
 // GetEtag - calculate ETag for file
-func GetEtag(path string) string {
+func GetEtag(path string, partSize int64) string {
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
 		return "unknown"
 	}
-	size := len(content)
-	if size <= PART_SIZE {
+	size := int64(len(content))
+	if size <= partSize {
 		hash := md5.Sum(content)
 		return fmt.Sprintf("\"%x\"", hash)
 	}
 	parts := 0
-	pos := 0
+	var pos int64
 	contentToHash := make([]byte, 0)
 	for size > pos {
-		endpos := pos + PART_SIZE
+		endpos := pos + partSize
 		if endpos >= size {
 			endpos = size
 		}
 		hash := md5.Sum(content[pos:endpos])
 		contentToHash = append(contentToHash, hash[:]...)
-		pos += PART_SIZE
+		pos += partSize
 		parts++
 	}
 	hash := md5.Sum(contentToHash)

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"io"
+	"os"
+)
+
+func copyFile(srcFile string, dstFile string) error {
+	src, err := os.Open(srcFile)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+	dst, err := os.Create(dstFile)
+	if err != nil {
+		return err
+	}
+	defer dst.Close()
+	if _, err = io.Copy(dst, src); err != nil {
+		return err
+	}
+	return nil
+}
+
+func moveFile(srcFile string, dstFile string) error {
+	err := os.Rename(srcFile, dstFile)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## add create-tables command implementation
when restoring to fresh installation of Clickhouse a step to recreate databases and tables had to be done manually. now create-tables method takes metadata information stored with backup and recreates all objects including distributed tables (they are created last). tables should not exist before running this command.

## change convert partition method to support custom partitioning key
convertPartition was expecting one of two:
- legacy partitioning key toYYYYMM(date_column)
- partitioning key based on data YYYY-MM-DD

as cited in documentation https://clickhouse.yandex/docs/en/operations/table_engines/custom_partitioning_key/ name of partition same as in system.parts table can be used. this is also same as used in file name. this means just that part itself may be used in ATTACH PARTITION query.

## make partition size for S3 object configurable
there was a hard coded value equal to 5 MB. this is saved as default value, but now it may be changed via configuration file.

## add -m, move flag to move instead of copy
to save disk space, partitions from backup folder may be moved, not copied

add documentation comments and fix some comments. no code changes