### PR TITLE
Some improvements for corner cases

### DIFF
--- a/main.go
+++ b/main.go
@@ -522,29 +522,14 @@ func clean(config Config, dryRun bool) error {
 		}
 	}
 	shadowDir := path.Join(dataPath, "shadow")
+	if _, err := os.Stat(shadowDir); os.IsNotExist(err) {
+		log.Printf("%s directory does not exist, nothing to do", shadowDir)
+		return nil
+	}
 	log.Printf("remove contents from directory %v", shadowDir)
 	if !dryRun {
 		if err := cleanDir(shadowDir); err != nil {
 			return fmt.Errorf("can't remove contents from directory %v: %v", shadowDir, err)
-		}
-	}
-	return nil
-}
-
-func cleanDir(dir string) error {
-	d, err := os.Open(dir)
-	if err != nil {
-		return err
-	}
-	defer d.Close()
-	names, err := d.Readdirnames(-1)
-	if err != nil {
-		return err
-	}
-	for _, name := range names {
-		err = os.RemoveAll(filepath.Join(dir, name))
-		if err != nil {
-			return err
 		}
 	}
 	return nil

--- a/utils.go
+++ b/utils.go
@@ -3,6 +3,7 @@ package main
 import (
 	"io"
 	"os"
+	"path/filepath"
 )
 
 func copyFile(srcFile string, dstFile string) error {
@@ -26,6 +27,25 @@ func moveFile(srcFile string, dstFile string) error {
 	err := os.Rename(srcFile, dstFile)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+func cleanDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	names, err := d.Readdirnames(-1)
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		err = os.RemoveAll(filepath.Join(dir, name))
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## do not allow freeze if shadow dir is not empty

Current behaviour leads to some sophisticated cases during restore: if
shadow dir already had any partitions, those are either old, because
partitions were overwritten, or same and a new hard link will be
created. In both of these cases files will be uploaded to S3. During
restore there is no method to distinguish such parts.
So, we need to have shadow dir empty, to have consistent current copy
of data in Clickhouse. This can be easily done via clean command.

## do not throw error if there are no partitions in Clickhouse

In case there are no actual data (partitions) in Clickhouse just log
a message about this and quit.

## do not throw error during restore if there are no partitions

In case a backup was made which does not have partitions (shadow dir is
empty) but metadata is there and may be used for creating tables, we
just log a message, that there is nothing to do.

## minor change in create-tables when getting Clickhouse data path

## do not throw error during clean if shadow dir is absent and move cleanDir function to utils