### PR TITLE
Fallback to global "config" flag

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -237,7 +237,7 @@ func (s *S3) UploadDirectory(localPath string, dstPath string) error {
 }
 
 // UploadFile - synchronize localPath to dstPath on s3
-func (s *S3) UploadFile(localPath string, dstPath string) error {
+func (s *S3) UploadFile(config *Config, localPath string, dstPath string) error {
 	uploader := s3manager.NewUploader(s.session)
 	uploader.PartSize = config.S3.PartSize
 


### PR DESCRIPTION
**Why**
Inability to specify global flags after command creates idiosyncrasies in the mind of a user.

**How**
`urfave/cli` will ship with fix included in their v2 API: https://github.com/urfave/cli/pull/410/files
Unfortunately, their development process seems slow. This hacky thing traverses to global config flag if the local one is not found. And it executes in the context of a `cli.Command`. The same logic is already applied to `dry-run`, alas we have to do a tad bit more with the config string flag.

The workaround is hacky and applies only to config flag parsing. But I think the end user would be happier, and that is a major consideration.