### PR TITLE
Support for SSE AES256 on S3

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -109,7 +109,9 @@ s3:
   backups_to_keep_s3: 0        # BACKUPS_TO_KEEP_S3
   compression_level: 1         # S3_COMPRESSION_LEVEL
   # supports 'tar', 'lz4', 'bzip2', 'gzip', 'sz', 'xz'
-  compression_format: gzip      # S3_COMPRESSION_FORMAT
+  compression_format: gzip     # S3_COMPRESSION_FORMAT
+  # empty (default), AES256, or aws:kms
+  sse: AES256                  # S3_SSE
 ```
 
 ## ATTENTION!

--- a/config.go
+++ b/config.go
@@ -33,6 +33,7 @@ type S3Config struct {
 	BackupsToKeepS3    int    `yaml:"backups_to_keep_s3" envconfig:"BACKUPS_TO_KEEP_S3"`
 	CompressionLevel   int    `yaml:"compression_level" envconfig:"S3_COMPRESSION_LEVEL"`
 	CompressionFormat  string `yaml:"compression_format" envconfig:"S3_COMPRESSION_FORMAT"`
+	SSE                string `yaml:"sse" envconfig:"S3_SSE"`
 }
 
 // ClickHouseConfig - clickhouse settings section
@@ -100,6 +101,7 @@ func defaultConfig() *Config {
 			BackupsToKeepS3:    0,
 			CompressionLevel:   1,
 			CompressionFormat:  "gzip",
+			SSE:                "",
 		},
 	}
 }

--- a/s3.go
+++ b/s3.go
@@ -173,7 +173,7 @@ func (s *S3) CompressedStreamUpload(localPath, s3Path, diffFromPath string) erro
 		if ok && aerr.Code() != "NotFound" {
 			return err
 		}
-	} else if err == nil && *head.ContentLength > 0 {
+	} else if *head.ContentLength > 0 {
 		return fmt.Errorf("'%s' already uploaded", archiveName)
 	}
 
@@ -290,11 +290,16 @@ func (s *S3) CompressedStreamUpload(localPath, s3Path, diffFromPath string) erro
 	uploader := s3manager.NewUploader(s.session)
 	uploader.Concurrency = 10
 	uploader.PartSize = s.Config.PartSize
+	var sse *string
+	if s.Config.SSE != "" {
+		sse = aws.String(s.Config.SSE)
+	}
 	if _, err := uploader.Upload(&s3manager.UploadInput{
-		ACL:    aws.String(s.Config.ACL),
-		Bucket: aws.String(s.Config.Bucket),
-		Key:    aws.String(archiveName),
-		Body:   body,
+		ACL:                  aws.String(s.Config.ACL),
+		Bucket:               aws.String(s.Config.Bucket),
+		Key:                  aws.String(archiveName),
+		Body:                 body,
+		ServerSideEncryption: sse,
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
This pull request adds support for [server-side encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html) on S3 buckets.

Note: those changes only allow for AES256 encryption. When using aws:kms, additional arguments (keys) will need to be passed. This is outside the scope of this PR.