### PR TITLE
install from sources doesn't work — fix command

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -45,7 +45,7 @@ docker run --rm -it --network host -v "/var/lib/clickhouse:/var/lib/clickhouse" 
 - Or get from the sources:
 
 ```shell
-go get github.com/AlexAkulov/clickhouse-backup
+GO111MODULE=on go get github.com/AlexAkulov/clickhouse-backup
 ```
 
 ## Usage


### PR DESCRIPTION
`GO111MODULE=on` must be used, otherwise go is not able to build correctly.

You are not alone — see https://github.com/google/ko#installation for example.