### PR TITLE
fix partition id

### DIFF
--- a/pkg/chbackup/clickhouse.go
+++ b/pkg/chbackup/clickhouse.go
@@ -323,29 +323,10 @@ func (ch *ClickHouse) CopyData(table BackupTable) error {
 	return nil
 }
 
-func convertPartition(detachedTableFolder string) string {
-	parts := strings.Split(detachedTableFolder, "_")
-	if parts[0] == "all" {
-		// table is not partitioned at all
-		// ENGINE = MergeTree ORDER BY id
-		return "tuple()"
-	}
-	// in case a custom partitioning key is used this is a partition name
-	// same as in system.parts table, it may be used in ALTER TABLE queries
-	// https://clickhouse.yandex/docs/en/operations/table_engines/custom_partitioning_key/
-	return fmt.Sprintf("ID '%s'", parts[0])
-}
-
 // AttachPatritions - execute ATTACH command for specific table
 func (ch *ClickHouse) AttachPatritions(table BackupTable) error {
-	attachedParts := make(map[string]struct{})
 	for _, partition := range table.Partitions {
-		partName := convertPartition(partition.Name)
-		if _, ok := attachedParts[partName]; ok {
-			continue
-		}
-		query := fmt.Sprintf("ALTER TABLE `%s`.`%s` ATTACH PARTITION %s", table.Database, table.Name, partName)
-		attachedParts[partName] = struct{}{}
+		query := fmt.Sprintf("ALTER TABLE `%s`.`%s` ATTACH PART '%s'", table.Database, table.Name, partition.Name)
 		log.Println(query)
 		if _, err := ch.conn.Exec(query); err != nil {
 			return err

--- a/pkg/chbackup/clickhouse.go
+++ b/pkg/chbackup/clickhouse.go
@@ -330,12 +330,6 @@ func convertPartition(detachedTableFolder string) string {
 		// ENGINE = MergeTree ORDER BY id
 		return "tuple()"
 	}
-	if len(parts) == 5 {
-		// legacy partitioning based on month: toYYYYMM(date_column)
-		// in this case we return YYYYMM
-		// ENGINE = MergeTree(Date, (TimeStamp, Log), 8192)
-		return parts[0][:6]
-	}
 	// in case a custom partitioning key is used this is a partition name
 	// same as in system.parts table, it may be used in ALTER TABLE queries
 	// https://clickhouse.yandex/docs/en/operations/table_engines/custom_partitioning_key/


### PR DESCRIPTION
The removed code calculates the following table's partition id incorrectly.

For legacy tables (such as following `test_orders1`), partition ID is `parts[0][:6]`. len(parts) is 5(original) or 6 (mutated).

For new tables (such as following `test_orders2`, and `test_orders3`), partition ID is `parts[0]`.
 len(parts) is 4(original) or 5 (mutated).

It's not stable to calculate partition ID from part directory name.

I've tested this pr with CK 19.15.3.6-stable.
```
CREATE TABLE test_orders1 (
    order_id String,
    order_date Date,
    order_time DateTime,
    amount Float32
) ENGINE = MergeTree(order_date, (order_time, order_id), 8192);

CREATE TABLE test_orders2 (
    order_id String,
    order_time DateTime,
    amount Float32
) ENGINE = MergeTree()
PARTITION BY toYYYYMM(order_time)
ORDER BY (order_time, order_id);

CREATE TABLE test_orders3 AS test_orders2
ENGINE = MergeTree()
PARTITION BY toYYYYMMDD(order_time)
ORDER BY (order_time, order_id);

CREATE TABLE test_orders4 AS test_orders2
ENGINE = MergeTree()
ORDER BY (order_time, order_id);

INSERT INTO test_orders1(order_id, order_date, order_time, amount) VALUES ('1', '0000-00-00', '0000-00-00 00:00:00', 10),  ('2', '2019-01-01', '2019-01-01 00:00:00', 20);

INSERT INTO test_orders2(order_id, order_time, amount) SELECT order_id, order_time, amount FROM test_orders1;

INSERT INTO test_orders3(order_id, order_time, amount) SELECT order_id, order_time, amount FROM test_orders1;

INSERT INTO test_orders4(order_id, order_time, amount) SELECT order_id, order_time, amount FROM test_orders1;

SELECT table, partition, name, partition_id, active FROM system.parts WHERE table like 'test_orders%' ORDER BY table, partition_id;
┌─table────────┬─partition─┬─name────────────────────┬─partition_id─┬─active─┐
│ test_orders1 │ 197001    │ 19700101_19700101_1_1_0 │ 197001       │      1 │
│ test_orders1 │ 201901    │ 20190101_20190101_2_2_0 │ 201901       │      1 │
│ test_orders2 │ 197001    │ 197001_2_2_0            │ 197001       │      1 │
│ test_orders2 │ 201901    │ 201901_1_1_0            │ 201901       │      1 │
│ test_orders3 │ 19700101  │ 19700101_2_2_0          │ 19700101     │      1 │
│ test_orders3 │ 20190101  │ 20190101_1_1_0          │ 20190101     │      1 │
│ test_orders4 │ tuple()   │ all_1_1_0               │ all          │      1 │
└──────────────┴───────────┴─────────────────────────┴──────────────┴────────┘


ALTER TABLE test_orders1 UPDATE amount=amount*2 WHERE order_time>='2019-01-01 00:00:00';
ALTER TABLE test_orders2 UPDATE amount=amount*2 WHERE order_time>='2019-01-01 00:00:00';
ALTER TABLE test_orders3 UPDATE amount=amount*2 WHERE order_time>='2019-01-01 00:00:00';
ALTER TABLE test_orders4 UPDATE amount=amount*2 WHERE order_time>='2019-01-01 00:00:00';

SELECT table, partition, name, partition_id, active FROM system.parts WHERE table like 'test_orders%' ORDER BY table, partition_id;
┌─table────────┬─partition─┬─name──────────────────────┬─partition_id─┬─active─┐
│ test_orders1 │ 197001    │ 19700101_19700101_1_1_0   │ 197001       │      0 │
│ test_orders1 │ 197001    │ 19700101_19700101_1_1_0_3 │ 197001       │      1 │
│ test_orders1 │ 201901    │ 20190101_20190101_2_2_0   │ 201901       │      0 │
│ test_orders1 │ 201901    │ 20190101_20190101_2_2_0_3 │ 201901       │      1 │
│ test_orders2 │ 197001    │ 197001_2_2_0              │ 197001       │      0 │
│ test_orders2 │ 197001    │ 197001_2_2_0_3            │ 197001       │      1 │
│ test_orders2 │ 201901    │ 201901_1_1_0              │ 201901       │      0 │
│ test_orders2 │ 201901    │ 201901_1_1_0_3            │ 201901       │      1 │
│ test_orders3 │ 19700101  │ 19700101_2_2_0            │ 19700101     │      0 │
│ test_orders3 │ 19700101  │ 19700101_2_2_0_3          │ 19700101     │      1 │
│ test_orders3 │ 20190101  │ 20190101_1_1_0            │ 20190101     │      0 │
│ test_orders3 │ 20190101  │ 20190101_1_1_0_3          │ 20190101     │      1 │
│ test_orders4 │ tuple()   │ all_1_1_0                 │ all          │      0 │
│ test_orders4 │ tuple()   │ all_1_1_0_2               │ all          │      1 │
└──────────────┴───────────┴───────────────────────────┴──────────────┴────────┘



```
