### PR TITLE
Added the option to skip certificate validation

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -103,21 +103,22 @@ clickhouse:
   skip_tables:                 # CLICKHOUSE_SKIP_TABLES
     - system.*
 s3:
-  access_key: ""               # S3_ACCESS_KEY
-  secret_key: ""               # S3_SECRET_KEY
-  bucket: ""                   # S3_BUCKET
-  endpoint: ""                 # S3_ENDPOINT
-  region: us-east-1            # S3_REGION
-  acl: private                 # S3_ACL
-  force_path_style: false      # S3_FORCE_PATH_STYLE
-  path: ""                     # S3_PATH
-  disable_ssl: false           # S3_DISABLE_SSL
-  part_size: 104857600         # S3_PART_SIZE
-  compression_level: 1         # S3_COMPRESSION_LEVEL
+  access_key: ""                  # S3_ACCESS_KEY
+  secret_key: ""                  # S3_SECRET_KEY
+  bucket: ""                      # S3_BUCKET
+  endpoint: ""                    # S3_ENDPOINT
+  region: us-east-1               # S3_REGION
+  acl: private                    # S3_ACL
+  force_path_style: false         # S3_FORCE_PATH_STYLE
+  path: ""                        # S3_PATH
+  disable_ssl: false              # S3_DISABLE_SSL
+  part_size: 104857600            # S3_PART_SIZE
+  compression_level: 1            # S3_COMPRESSION_LEVEL
   # supports 'tar', 'lz4', 'bzip2', 'gzip', 'sz', 'xz'
-  compression_format: gzip     # S3_COMPRESSION_FORMAT
+  compression_format: gzip        # S3_COMPRESSION_FORMAT
   # empty (default), AES256, or aws:kms
-  sse: AES256                  # S3_SSE
+  sse: AES256                     # S3_SSE
+  disable_cert_verification: true # S3_DISABLE_CERT_VERIFICATION
 gcs:
   credentials_file: ""         # GCS_CREDENTIALS_FILE
   credentials_json: ""         # GCS_CREDENTIALS_JSON

--- a/pkg/chbackup/config.go
+++ b/pkg/chbackup/config.go
@@ -37,19 +37,20 @@ type GCSConfig struct {
 
 // S3Config - s3 settings section
 type S3Config struct {
-	AccessKey         string `yaml:"access_key" envconfig:"S3_ACCESS_KEY"`
-	SecretKey         string `yaml:"secret_key" envconfig:"S3_SECRET_KEY"`
-	Bucket            string `yaml:"bucket" envconfig:"S3_BUCKET"`
-	Endpoint          string `yaml:"endpoint" envconfig:"S3_ENDPOINT"`
-	Region            string `yaml:"region" envconfig:"S3_REGION"`
-	ACL               string `yaml:"acl" envconfig:"S3_ACL"`
-	ForcePathStyle    bool   `yaml:"force_path_style" envconfig:"S3_FORCE_PATH_STYLE"`
-	Path              string `yaml:"path" envconfig:"S3_PATH"`
-	DisableSSL        bool   `yaml:"disable_ssl" envconfig:"S3_DISABLE_SSL"`
-	PartSize          int64  `yaml:"part_size" envconfig:"S3_PART_SIZE"`
-	CompressionLevel  int    `yaml:"compression_level" envconfig:"S3_COMPRESSION_LEVEL"`
-	CompressionFormat string `yaml:"compression_format" envconfig:"S3_COMPRESSION_FORMAT"`
-	SSE               string `yaml:"sse" envconfig:"S3_SSE"`
+	AccessKey               string `yaml:"access_key" envconfig:"S3_ACCESS_KEY"`
+	SecretKey               string `yaml:"secret_key" envconfig:"S3_SECRET_KEY"`
+	Bucket                  string `yaml:"bucket" envconfig:"S3_BUCKET"`
+	Endpoint                string `yaml:"endpoint" envconfig:"S3_ENDPOINT"`
+	Region                  string `yaml:"region" envconfig:"S3_REGION"`
+	ACL                     string `yaml:"acl" envconfig:"S3_ACL"`
+	ForcePathStyle          bool   `yaml:"force_path_style" envconfig:"S3_FORCE_PATH_STYLE"`
+	Path                    string `yaml:"path" envconfig:"S3_PATH"`
+	DisableSSL              bool   `yaml:"disable_ssl" envconfig:"S3_DISABLE_SSL"`
+	PartSize                int64  `yaml:"part_size" envconfig:"S3_PART_SIZE"`
+	CompressionLevel        int    `yaml:"compression_level" envconfig:"S3_COMPRESSION_LEVEL"`
+	CompressionFormat       string `yaml:"compression_format" envconfig:"S3_COMPRESSION_FORMAT"`
+	SSE                     string `yaml:"sse" envconfig:"S3_SSE"`
+	DisableCertVerification bool   `yaml:"disable_cert_verification" envconfig:"S3_DISABLE_CERT_VERIFICATION"`
 }
 
 // ClickHouseConfig - clickhouse settings section
@@ -114,12 +115,13 @@ func DefaultConfig() *Config {
 			},
 		},
 		S3: S3Config{
-			Region:            "us-east-1",
-			DisableSSL:        false,
-			ACL:               "private",
-			PartSize:          100 * 1024 * 1024,
-			CompressionLevel:  1,
-			CompressionFormat: "gzip",
+			Region:                  "us-east-1",
+			DisableSSL:              false,
+			ACL:                     "private",
+			PartSize:                100 * 1024 * 1024,
+			CompressionLevel:        1,
+			CompressionFormat:       "gzip",
+			DisableCertVerification: false,
 		},
 		GCS: GCSConfig{
 			CompressionLevel:  1,


### PR DESCRIPTION
Added the option to skip certificate validation when using S3. We have a few internal S3 applicances that don't have valid certificates. This pull requests makes it possible for us to backup to those S3 appliances.