### PR TITLE
fix: parse schema error

### DIFF
--- a/pkg/chbackup/backup.go
+++ b/pkg/chbackup/backup.go
@@ -106,6 +106,9 @@ func parseSchemaPattern(metadataPath string, tablePattern string) (RestoreTables
 		database, _ := url.PathUnescape(parts[0])
 		table, _ := url.PathUnescape(parts[1])
 		tableName := fmt.Sprintf("%s.%s", database, table)
+		if strings.Contains(table, ".inner.") {
+			return nil
+		}
 		for _, p := range tablePatterns {
 			if matched, _ := filepath.Match(p, tableName); matched {
 				data, err := ioutil.ReadFile(filePath)


### PR DESCRIPTION
Executing the program of parsing schema occur an error where metadata has a materialized view, because materialized view contain the metadata of '.inner.', 'create materialized view ' and 'create .inner.xxx' are the same.