### PR TITLE
Separated clickhouse data and backup path

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -101,6 +101,7 @@ clickhouse:
   port: 9000                   # CLICKHOUSE_PORT
   timeout: 5m                  # CLICKHOUSE_TIMEOUT
   data_path: ""                # CLICKHOUSE_DATA_PATH
+  backup_path: "/opt/chbkp/"   # CLICKHOUSE_BACKUP_PATH
   skip_tables:                 # CLICKHOUSE_SKIP_TABLES
     - system.*
   timeout: 5m                  # CLICKHOUSE_TIMEOUT

--- a/pkg/chbackup/clickhouse.go
+++ b/pkg/chbackup/clickhouse.go
@@ -200,11 +200,7 @@ func (ch *ClickHouse) FreezeTable(table Table) error {
 
 // GetBackupTables - return list of backups of tables that can be restored
 func (ch *ClickHouse) GetBackupTables(backupName string) (map[string]BackupTable, error) {
-	dataPath, err := ch.GetDataPath()
-	if err != nil {
-		return nil, err
-	}
-	backupShadowPath := filepath.Join(dataPath, "backup", backupName, "shadow")
+	backupShadowPath := filepath.Join(getBackupPath(ch.Config.BackupPath), "backup", backupName, "shadow")
 	dbNum := 0
 	tableNum := 1
 	partNum := 2

--- a/pkg/chbackup/config.go
+++ b/pkg/chbackup/config.go
@@ -77,6 +77,7 @@ type ClickHouseConfig struct {
 	SkipTables   []string `yaml:"skip_tables" envconfig:"CLICKHOUSE_SKIP_TABLES"`
 	Timeout      string   `yaml:"timeout" envconfig:"CLICKHOUSE_TIMEOUT"`
 	FreezeByPart bool     `yaml:"freeze_by_part" envconfig:"CLICKHOUSE_FREEZE_BY_PART"`
+	BackupPath   string   `yaml:"backup_path" envconfig:"CLICKHOUSE_BACKUP_PATH"`
 }
 
 // LoadConfig - load config from file

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -220,10 +220,10 @@ func testRestoreLegacyBackupFormat(t *testing.T) {
 	time.Sleep(time.Second * 5)
 	fmt.Println("Create backup")
 	r.NoError(dockerExec("clickhouse-backup", "freeze"))
-	dockerExec("mkdir", "-p", "/var/lib/clickhouse/backup/old_format")
-	r.NoError(dockerExec("cp", "-r", "/var/lib/clickhouse/metadata", "/var/lib/clickhouse/backup/old_format/"))
-	r.NoError(dockerExec("mv", "/var/lib/clickhouse/shadow", "/var/lib/clickhouse/backup/old_format/"))
-	dockerExec("ls", "-lha", "/var/lib/clickhouse/backup/old_format/")
+	dockerExec("mkdir", "-p", "/opt/chbkp/backup/old_format")
+	r.NoError(dockerExec("cp", "-r", "/var/lib/clickhouse/metadata", "/opt/chbkp/backup/old_format/"))
+	r.NoError(dockerExec("mv", "/var/lib/clickhouse/shadow", "/opt/chbkp/backup/old_format/"))
+	dockerExec("ls", "-lha", "/opt/chbkp/backup/old_format/")
 
 	fmt.Println("Upload")
 	r.NoError(dockerExec("clickhouse-backup", "upload", "old_format"))
@@ -236,10 +236,10 @@ func testRestoreLegacyBackupFormat(t *testing.T) {
 	fmt.Println("Drop database")
 	r.NoError(ch.dropDatabase(dbName))
 
-	dockerExec("ls", "-lha", "/var/lib/clickhouse/backup")
+	dockerExec("ls", "-lha", "/opt/chbkp/backup")
 	fmt.Println("Delete backup")
-	r.NoError(dockerExec("/bin/rm", "-rf", "/var/lib/clickhouse/backup/old_format"))
-	dockerExec("ls", "-lha", "/var/lib/clickhouse/backup")
+	r.NoError(dockerExec("/bin/rm", "-rf", "/opt/chbkp/backup/old_format"))
+	dockerExec("ls", "-lha", "/opt/chbkp/backup")
 
 	fmt.Println("Download")
 	r.NoError(dockerExec("clickhouse-backup", "download", "old_format"))
@@ -252,7 +252,7 @@ func testRestoreLegacyBackupFormat(t *testing.T) {
 		r.NoError(ch.checkData(t, testData[i]))
 	}
 	fmt.Println("Clean")
-	r.NoError(dockerExec("/bin/rm", "-rf", "/var/lib/clickhouse/backup/old_format", "/var/lib/clickhouse/backup/increment_old_format", "/var/lib/clickhouse/shadow"))
+	r.NoError(dockerExec("/bin/rm", "-rf", "/opt/chbkp/backup/old_format", "/opt/chbkp/backup/increment_old_format", "/var/lib/clickhouse/shadow"))
 	r.NoError(dockerExec("clickhouse-backup", "delete", "remote", "old_format.tar.gz"))
 }
 
@@ -302,10 +302,10 @@ func testCommon(t *testing.T) {
 	fmt.Println("Drop database")
 	r.NoError(ch.dropDatabase(dbName))
 
-	dockerExec("ls", "-lha", "/var/lib/clickhouse/backup")
+	dockerExec("ls", "-lha", "/opt/chbkp/backup")
 	fmt.Println("Delete backup")
-	r.NoError(dockerExec("/bin/rm", "-rf", "/var/lib/clickhouse/backup/test_backup", "/var/lib/clickhouse/backup/increment"))
-	dockerExec("ls", "-lha", "/var/lib/clickhouse/backup")
+	r.NoError(dockerExec("/bin/rm", "-rf", "/opt/chbkp/backup/test_backup", "/opt/chbkp/backup/increment"))
+	dockerExec("ls", "-lha", "/opt/chbkp/backup")
 
 	fmt.Println("Download")
 	r.NoError(dockerExec("clickhouse-backup", "download", "test_backup"))
@@ -324,10 +324,10 @@ func testCommon(t *testing.T) {
 	fmt.Println("Drop database")
 	r.NoError(ch.dropDatabase(dbName))
 
-	dockerExec("ls", "-lha", "/var/lib/clickhouse/backup")
+	dockerExec("ls", "-lha", "/opt/chbkp/backup")
 	fmt.Println("Delete backup")
-	r.NoError(dockerExec("/bin/rm", "-rf", "/var/lib/clickhouse/backup/test_backup", "/var/lib/clickhouse/backup/increment"))
-	dockerExec("ls", "-lha", "/var/lib/clickhouse/backup")
+	r.NoError(dockerExec("/bin/rm", "-rf", "/opt/chbkp/backup/test_backup", "/opt/chbkp/backup/increment"))
+	dockerExec("ls", "-lha", "/opt/chbkp/backup")
 
 	fmt.Println("Download increment")
 	r.NoError(dockerExec("clickhouse-backup", "download", "increment"))
@@ -343,7 +343,7 @@ func testCommon(t *testing.T) {
 	}
 
 	fmt.Println("Clean")
-	r.NoError(dockerExec("/bin/rm", "-rf", "/var/lib/clickhouse/backup/test_backup", "/var/lib/clickhouse/backup/increment"))
+	r.NoError(dockerExec("/bin/rm", "-rf", "/opt/chbkp/backup/test_backup", "/opt/chbkp/backup/increment"))
 	r.NoError(dockerExec("clickhouse-backup", "delete", "remote", "test_backup.tar.gz"))
 	r.NoError(dockerExec("clickhouse-backup", "delete", "remote", "increment.tar.gz"))
 }


### PR DESCRIPTION
In some usecases (namely kubernetes for myself). You might want to avoid writing to `/var/lib/clickhouse` externally, so I think that separating data and backup path is useful. 

In my case I'm limiting the clickhouse-backup docker to only have read permissions on /var/lib/clickhouse so I can't add backups there, nor can I clean the "shadow" folder. Is leaving the shadow folder and overwriting it every time I create a backup a problem?