### PR TITLE
Flashback restore feature

### DIFF
--- a/main.go
+++ b/main.go
@@ -151,6 +151,20 @@ func main() {
 			),
 		},
 		{
+			Name:      "flashback",
+			Usage:     "flashback to backup",
+			UsageText: "clickhouse-backup flashback [-t, --tables=<db>.<table>] <backup_name>",
+			Action: func(c *cli.Context) error {
+				return chbackup.Flashback(*getConfig(c), c.Args().First(), c.String("t"))
+			},
+			Flags: append(cliapp.Flags,
+				cli.StringFlag{
+					Name:   "table, tables, t",
+					Hidden: false,
+				},
+			),
+		},
+		{
 			Name:      "delete",
 			Usage:     "Delete specific backup",
 			UsageText: "clickhouse-backup delete <local|remote> <backup_name>",

--- a/pkg/chbackup/backup.go
+++ b/pkg/chbackup/backup.go
@@ -1,6 +1,7 @@
 package chbackup
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -17,6 +18,10 @@ import (
 const (
 	// BackupTimeFormat - default backup name format
 	BackupTimeFormat = "2006-01-02T15-04-05"
+)
+
+const (
+	hashfile = "parts.hash"
 )
 
 var (
@@ -90,6 +95,8 @@ func parseSchemaPattern(metadataPath string, tablePattern string) (RestoreTables
 	distributedTables := RestoreTables{}
 	viewTables := RestoreTables{}
 	tablePatterns := []string{"*"}
+
+	//log.Printf("tp1 = %s", tablePattern)
 	if tablePattern != "" {
 		tablePatterns = strings.Split(tablePattern, ",")
 	}
@@ -98,7 +105,9 @@ func parseSchemaPattern(metadataPath string, tablePattern string) (RestoreTables
 			return nil
 		}
 		p := filepath.ToSlash(filePath)
+		//log.Printf("p1 = %s", p)
 		p = strings.Trim(strings.TrimPrefix(strings.TrimSuffix(p, ".sql"), metadataPath), "/")
+		//log.Printf("p2 = %s", p)
 		parts := strings.Split(p, "/")
 		if len(parts) != 2 {
 			return nil
@@ -107,6 +116,7 @@ func parseSchemaPattern(metadataPath string, tablePattern string) (RestoreTables
 		table, _ := url.PathUnescape(parts[1])
 		tableName := fmt.Sprintf("%s.%s", database, table)
 		for _, p := range tablePatterns {
+			//log.Printf("p3 = %s", p)
 			if matched, _ := filepath.Match(p, tableName); matched {
 				data, err := ioutil.ReadFile(filePath)
 				if err != nil {
@@ -130,6 +140,9 @@ func parseSchemaPattern(metadataPath string, tablePattern string) (RestoreTables
 				regularTables = addRestoreTable(regularTables, restoreTable)
 				return nil
 			}
+			/*else {
+				log.Printf("No match %s %s", p, tableName)
+			}*/
 		}
 		return nil
 	}); err != nil {
@@ -370,6 +383,56 @@ func Freeze(config Config, tablePattern string) error {
 	return nil
 }
 
+// CopyPartHashes - Copy data parts hashes by tablePattern
+func CopyPartHashes(config Config, tablePattern string, backupName string) error {
+	var allparts map[string][]Partition
+	allparts = make(map[string][]Partition)
+
+	ch := &ClickHouse{
+		Config: &config.ClickHouse,
+	}
+	if err := ch.Connect(); err != nil {
+		return fmt.Errorf("can't connect to clickhouse: %v", err)
+	}
+	defer ch.Close()
+
+	dataPath, err := ch.GetDataPath()
+	if err != nil || dataPath == "" {
+		return fmt.Errorf("can't get data path from clickhouse: %v\nyou can set data_path in config file", err)
+	}
+
+	allTables, err := ch.GetTables()
+	if err != nil {
+		return fmt.Errorf("can't get tables from clickhouse: %v", err)
+	}
+	backupTables := parseTablePatternForFreeze(allTables, tablePattern)
+	if len(backupTables) == 0 {
+		return fmt.Errorf("there are no tables in clickhouse, create something to freeze")
+	}
+	for _, table := range backupTables {
+		if table.Skip {
+			log.Printf("Skip '%s.%s'", table.Database, table.Name)
+			continue
+		}
+
+		parts, err := ch.GetPartitions(table)
+		if err != nil {
+			return err
+		}
+		allparts[table.Database+"."+table.Name] = parts
+
+	}
+	log.Println("Writing part hashes")
+	byteArray, err := json.MarshalIndent(allparts, "", " ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	hashPartsPath := path.Join(dataPath, "backup", backupName, hashfile)
+	_ = ioutil.WriteFile(hashPartsPath, byteArray, 0644)
+
+	return nil
+}
+
 // NewBackupName - return default backup name
 func NewBackupName() string {
 	return time.Now().UTC().Format(BackupTimeFormat)
@@ -392,10 +455,17 @@ func CreateBackup(config Config, backupName, tablePattern string) error {
 	if err := os.MkdirAll(backupPath, os.ModePerm); err != nil {
 		return fmt.Errorf("can't create backup: %v", err)
 	}
+
 	log.Printf("Create backup '%s'", backupName)
 	if err := Freeze(config, tablePattern); err != nil {
 		return err
 	}
+
+	log.Printf("Copy part hashes")
+	if err := CopyPartHashes(config, tablePattern, backupName); err != nil {
+		return err
+	}
+
 	log.Println("Copy metadata")
 	schemaList, err := parseSchemaPattern(path.Join(dataPath, "metadata"), tablePattern)
 	if err != nil {
@@ -453,6 +523,104 @@ func Restore(config Config, backupName string, tablePattern string, schemaOnly b
 	return nil
 }
 
+// Flashback - restore tables matched by tablePattern from backupName by restroing only modified parts.
+func Flashback(config Config, backupName string, tablePattern string) error {
+	/*if schemaOnly || (schemaOnly == dataOnly) {
+		err := restoreSchema(config, backupName, tablePattern)
+		if err != nil {
+			return err
+		}
+	}
+	if dataOnly || (schemaOnly == dataOnly) {
+		err := RestoreData(config, backupName, tablePattern)
+		if err != nil {
+			return err
+		}
+	}*/
+
+	err := FlashBackData(config, backupName, tablePattern)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// FlashBackData - restore data for tables matched by tablePattern from backupName
+func FlashBackData(config Config, backupName string, tablePattern string) error {
+	if backupName == "" {
+		PrintLocalBackups(config, "all")
+		return fmt.Errorf("select backup for restore")
+	}
+
+	dataPath := getDataPath(config)
+
+	if dataPath == "" {
+		return ErrUnknownClickhouseDataPath
+	}
+	ch := &ClickHouse{
+		Config: &config.ClickHouse,
+	}
+	if err := ch.Connect(); err != nil {
+		return fmt.Errorf("can't connect to clickhouse: %v", err)
+	}
+	defer ch.Close()
+
+	allBackupTables, err := ch.GetBackupTables(backupName)
+	if err != nil {
+		return err
+	}
+
+	restoreTables := parseTablePatternForRestoreData(allBackupTables, tablePattern)
+
+	liveTables, err := ch.GetTables()
+
+	if err != nil {
+		return err
+	}
+	if len(restoreTables) == 0 {
+		return fmt.Errorf("backup doesn't have tables to restore")
+	}
+
+	missingTables := []string{}
+
+	for _, restoreTable := range restoreTables {
+		found := false
+		for _, liveTable := range liveTables {
+			if (restoreTable.Database == liveTable.Database) && (restoreTable.Name == liveTable.Name) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			missingTables = append(missingTables, fmt.Sprintf("%s.%s", restoreTable.Database, restoreTable.Name))
+
+			for _, newtable := range missingTables {
+				//log.Printf("newtable=%s", newtable)
+				err := restoreSchema(config, backupName, newtable)
+				if err != nil {
+					return err
+				}
+			}
+
+			FlashBackData(config, backupName, tablePattern)
+			return nil
+		}
+	}
+
+	diffInfos, _ := ch.ComputePartitionsDelta(restoreTables, liveTables)
+	for _, tableDiff := range diffInfos {
+
+		if err := ch.CopyDataDiff(tableDiff); err != nil {
+			return fmt.Errorf("can't restore '%s.%s': %v", tableDiff.btable.Database, tableDiff.btable.Name, err)
+		}
+
+		if err := ch.ApplyPartitionsChanges(tableDiff); err != nil {
+			return fmt.Errorf("can't attach partitions for table '%s.%s': %v", tableDiff.btable.Database, tableDiff.btable.Name, err)
+		}
+	}
+	return nil
+}
+
 // RestoreData - restore data for tables matched by tablePattern from backupName
 func RestoreData(config Config, backupName string, tablePattern string) error {
 	if backupName == "" {
@@ -503,7 +671,7 @@ func RestoreData(config Config, backupName string, tablePattern string) error {
 		if err := ch.CopyData(table); err != nil {
 			return fmt.Errorf("can't restore '%s.%s': %v", table.Database, table.Name, err)
 		}
-		if err := ch.AttachPatritions(table); err != nil {
+		if err := ch.AttachPartitions(table); err != nil {
 			return fmt.Errorf("can't attach partitions for table '%s.%s': %v", table.Database, table.Name, err)
 		}
 	}

--- a/pkg/chbackup/clickhouse.go
+++ b/pkg/chbackup/clickhouse.go
@@ -1,7 +1,9 @@
 package chbackup
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -34,8 +36,13 @@ type Table struct {
 
 // BackupPartition - struct representing Clickhouse partition
 type BackupPartition struct {
-	Name string
-	Path string
+	Partition                         string `json:"Partition"`
+	Name                              string `json:"Name"`
+	Path                              string `json:"Path"`
+	HashOfAllFiles                    string `json:"hash_of_all_files"`
+	HashOfUncompressedFiles           string `json:"hash_of_uncompressed_files"`
+	UncompressedHashOfCompressedFiles string `json:"uncompressed_hash_of_compressed_files"`
+	Active                            uint8  `json:"active"`
 }
 
 // BackupTable - struct to store additional information on partitions
@@ -65,6 +72,24 @@ type RestoreTable struct {
 
 // RestoreTables - slice of RestoreTable
 type RestoreTables []RestoreTable
+
+// Partition - partition info from system.parts
+type Partition struct {
+	Partition                         string `db:"partition"`
+	Name                              string `db:"name"`
+	Path                              string `db:"path"`
+	HashOfAllFiles                    string `db:"hash_of_all_files"`
+	HashOfUncompressedFiles           string `db:"hash_of_uncompressed_files"`
+	UncompressedHashOfCompressedFiles string `db:"uncompressed_hash_of_compressed_files"`
+	Active                            uint8  `db:"active"`
+}
+
+// PartDiff - Data part discrepancies infos
+type PartDiff struct {
+	btable           BackupTable
+	PartitionsAdd    []Partition
+	PartitionsRemove []Partition
+}
 
 // Sort - sorting BackupTables slice orderly by name
 func (rt RestoreTables) Sort() {
@@ -133,6 +158,16 @@ func (ch *ClickHouse) GetTables() ([]Table, error) {
 		}
 	}
 	return tables, nil
+}
+
+// GetPartitions - return slice of all partitions for a table
+func (ch *ClickHouse) GetPartitions(table Table) ([]Partition, error) {
+	partitions := make([]Partition, 0)
+	if err := ch.conn.Select(&partitions, fmt.Sprintf("select partition, name, path, active, hash_of_all_files,hash_of_uncompressed_files,uncompressed_hash_of_compressed_files from system.parts where database='%s' and table='%s';", table.Database, table.Name)); err != nil {
+		return nil, err
+	}
+
+	return partitions, nil
 }
 
 // GetVersion - returned ClickHouse version in number format
@@ -223,6 +258,20 @@ func (ch *ClickHouse) GetBackupTables(backupName string) (map[string]BackupTable
 		return nil, fmt.Errorf("can't get tables, %s is not a dir", backupShadowPath)
 	}
 
+	var allpartsBackup map[string][]Partition
+	hashPath := path.Join(dataPath, "backup", backupName, hashfile)
+	log.Printf("Reading part hashes %s", hashPath)
+	bytes, err := ioutil.ReadFile(hashPath)
+	if err != nil {
+		log.Printf("Unable to read hash file %s", hashPath)
+		//return nil, fmt.Errorf("Unable to read hash file %s", hashPath)
+	} else {
+		err = json.Unmarshal(bytes, &allpartsBackup)
+		if err != nil {
+			return nil, fmt.Errorf("issue occured while reading hash file %s", hashPath)
+		}
+	}
+
 	result := make(map[string]BackupTable)
 	err = filepath.Walk(backupShadowPath, func(filePath string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -235,13 +284,29 @@ func (ch *ClickHouse) GetBackupTables(backupName string) (map[string]BackupTable
 			if len(parts) != totalNum {
 				return nil
 			}
-			partition := BackupPartition{
-				Name: parts[partNum],
-				Path: filePath,
-			}
+
 			tDB, _ := url.PathUnescape(parts[dbNum])
 			tName, _ := url.PathUnescape(parts[tableNum])
 			fullTableName := fmt.Sprintf("%s.%s", tDB, tName)
+
+			allparthash := allpartsBackup[fullTableName]
+			var hoaf, houf, uhocf string
+			for _, parthash := range allparthash {
+				if parthash.Name == parts[partNum] {
+					hoaf = parthash.HashOfAllFiles
+					houf = parthash.HashOfUncompressedFiles
+					uhocf = parthash.UncompressedHashOfCompressedFiles
+				}
+			}
+
+			partition := BackupPartition{
+				Name:                              parts[partNum],
+				Path:                              filePath,
+				HashOfAllFiles:                    hoaf,
+				HashOfUncompressedFiles:           houf,
+				UncompressedHashOfCompressedFiles: uhocf,
+			}
+
 			if t, ok := result[fullTableName]; ok {
 				t.Partitions = append(t.Partitions, partition)
 				result[fullTableName] = t
@@ -283,6 +348,116 @@ func (ch *ClickHouse) Chown(filename string) error {
 	return os.Chown(filename, *ch.uid, *ch.gid)
 }
 
+// ComputePartitionsDelta - computes the data partitions to be added and removed between live and backup tables
+func (ch *ClickHouse) ComputePartitionsDelta(restoreTables []BackupTable, liveTables []Table) ([]PartDiff, error) {
+	var ftables []PartDiff
+
+	var partitions []Partition
+
+	log.Printf("Compute partitions discrepancies")
+
+	for _, rtable := range restoreTables {
+		var partsToAdd []Partition
+		var partsToRemove []Partition
+		for _, rpartition := range rtable.Partitions {
+			bfound := false
+			for _, liveTable := range liveTables {
+				if liveTable.Database == rtable.Database && liveTable.Name == rtable.Name {
+					livePartitions, _ := ch.GetPartitions(liveTable)
+					for _, livePartition := range livePartitions {
+						if livePartition.HashOfAllFiles == rpartition.HashOfAllFiles && livePartition.HashOfUncompressedFiles == rpartition.HashOfUncompressedFiles && livePartition.UncompressedHashOfCompressedFiles == rpartition.UncompressedHashOfCompressedFiles {
+							bfound = true
+							break
+						}
+					}
+				}
+			}
+			if !bfound {
+				partsToAdd = append(partsToAdd, Partition{Name: rpartition.Name, Path: rpartition.Path})
+			}
+		}
+
+		for _, ltable := range liveTables {
+			if ltable.Name == rtable.Name {
+				partitions, _ = ch.GetPartitions(ltable)
+				for _, livepart := range partitions {
+					bfound := false
+					for _, backuppart := range rtable.Partitions {
+						if livepart.HashOfAllFiles == backuppart.HashOfAllFiles && livepart.HashOfUncompressedFiles == backuppart.HashOfUncompressedFiles && livepart.UncompressedHashOfCompressedFiles == backuppart.UncompressedHashOfCompressedFiles {
+							bfound = true
+							break
+						}
+					}
+					if bfound == false {
+						partsToRemove = append(partsToRemove, livepart)
+					}
+				}
+			}
+		}
+		log.Printf("[%s.%s] Backup data parts to attach : %v ", rtable.Database, rtable.Name, partsToAdd)
+		log.Printf("[%s.%s] Live data parts to detach : %v ", rtable.Database, rtable.Name, partsToRemove)
+		ftables = append(ftables, PartDiff{rtable, partsToAdd, partsToRemove})
+	}
+	log.Printf("Compute partitions discrepancies. Done")
+
+	return ftables, nil
+}
+
+// CopyDataDiff - copy only partitions that will be attached to "detached" folder
+func (ch *ClickHouse) CopyDataDiff(diff PartDiff) error {
+	log.Printf("Prepare data for restoring '%s.%s'", diff.btable.Database, diff.btable.Name)
+	dataPath, err := ch.GetDataPath()
+	if err != nil {
+		return err
+	}
+	detachedParentDir := filepath.Join(dataPath, "data", TablePathEncode(diff.btable.Database), TablePathEncode(diff.btable.Name), "detached")
+	os.MkdirAll(detachedParentDir, 0750)
+	ch.Chown(detachedParentDir)
+
+	for _, partition := range diff.PartitionsAdd {
+
+		log.Printf("Processing partition %s (%s)", partition.Name, partition.Path)
+		detachedPath := filepath.Join(detachedParentDir, partition.Name)
+		info, err := os.Stat(detachedPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				// partition dir does not exist, creating
+				os.MkdirAll(detachedPath, 0750)
+			} else {
+				return err
+			}
+		} else if !info.IsDir() {
+			return fmt.Errorf("'%s' should be directory or absent", detachedPath)
+		}
+		ch.Chown(detachedPath)
+
+		if err := filepath.Walk(partition.Path, func(filePath string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			filePath = filepath.ToSlash(filePath) // fix Windows slashes
+			filename := strings.Trim(strings.TrimPrefix(filePath, partition.Path), "/")
+			dstFilePath := filepath.Join(detachedPath, filename)
+			if info.IsDir() {
+				os.MkdirAll(dstFilePath, 0750)
+				return ch.Chown(dstFilePath)
+			}
+			if !info.Mode().IsRegular() {
+				log.Printf("'%s' is not a regular file, skipping.", filePath)
+				return nil
+			}
+			if err := os.Link(filePath, dstFilePath); err != nil {
+				return fmt.Errorf("failed to crete hard link '%s' -> '%s': %v", filePath, dstFilePath, err)
+			}
+			return ch.Chown(dstFilePath)
+		}); err != nil {
+			return fmt.Errorf("error during filepath.Walk for partition '%s': %v", partition.Path, err)
+		}
+	}
+	log.Printf("Prepare data for restoring '%s.%s'. DONE", diff.btable.Database, diff.btable.Name)
+	return nil
+}
+
 // CopyData - copy partitions for specific table to detached folder
 func (ch *ClickHouse) CopyData(table BackupTable) error {
 	log.Printf("Prepare data for restoring '%s.%s'", table.Database, table.Name)
@@ -295,6 +470,7 @@ func (ch *ClickHouse) CopyData(table BackupTable) error {
 	ch.Chown(detachedParentDir)
 
 	for _, partition := range table.Partitions {
+		log.Printf("partition name is %s (%s)", partition.Name, partition.Path)
 		detachedPath := filepath.Join(detachedParentDir, partition.Name)
 		info, err := os.Stat(detachedPath)
 		if err != nil {
@@ -335,8 +511,89 @@ func (ch *ClickHouse) CopyData(table BackupTable) error {
 	return nil
 }
 
-// AttachPatritions - execute ATTACH command for specific table
-func (ch *ClickHouse) AttachPatritions(table BackupTable) error {
+// ApplyPartitionsChanges - add/remove partitions to/from the live table
+func (ch *ClickHouse) ApplyPartitionsChanges(table PartDiff) error {
+	var query string
+	dataPath, err := ch.GetDataPath()
+	if err != nil {
+		return err
+	}
+	for _, partition := range table.PartitionsAdd {
+		query = fmt.Sprintf("ALTER TABLE `%s`.`%s` ATTACH PART '%s'", table.btable.Database, table.btable.Name, partition.Name)
+		log.Println(query)
+		if _, err := ch.conn.Exec(query); err != nil {
+			return err
+		}
+	}
+
+	if len(table.PartitionsRemove) > 0 {
+		partList := make(map[string]struct{})
+
+		for _, partition := range table.PartitionsRemove {
+			log.Printf("Removing %s", partition.Path)
+
+			//partitionName := partition.Name[:strings.IndexByte(partition.Name, '_')]
+			partitionName := partition.Partition
+
+			if _, ok := partList[partitionName]; !ok {
+				partList[partitionName] = struct{}{}
+			}
+		}
+
+		for partname := range partList {
+			/*if partname == "all" {
+				query = fmt.Sprintf("DETACH TABLE `%s`.`%s`", table.btable.Database, table.btable.Name)
+			} else {*/
+			query = fmt.Sprintf("ALTER TABLE `%s`.`%s` DETACH PARTITION %s", table.btable.Database, table.btable.Name, partname)
+			//}
+			log.Println(query)
+			if _, err := ch.conn.Exec(query); err != nil {
+				return err
+			}
+		}
+
+		detachedParentDir := filepath.Join(dataPath, "data", TablePathEncode(table.btable.Database), TablePathEncode(table.btable.Name), "detached")
+
+		for _, partition := range table.PartitionsRemove {
+			detachedPath := filepath.Join(detachedParentDir, partition.Name)
+			log.Printf("[%s.%s] Removing %s", table.btable.Database, table.btable.Name, detachedPath)
+			e := os.RemoveAll(detachedPath)
+			if e != nil {
+				return e
+			}
+		}
+
+		for partname := range partList {
+			if partname == "all" {
+				query = fmt.Sprintf("ATTACH TABLE `%s`.`%s`", table.btable.Database, table.btable.Name)
+			} else {
+				query = fmt.Sprintf("ALTER TABLE `%s`.`%s` ATTACH PARTITION %s", table.btable.Database, table.btable.Name, partname)
+			}
+			log.Println(query)
+			if _, err := ch.conn.Exec(query); err != nil {
+				return err
+			}
+
+		}
+
+		/*e := os.RemoveAll(partition.Path)
+		if e != nil {
+			return e
+		}*/
+
+		/*query = fmt.Sprintf("ATTACH TABLE `%s`.`%s`", table.btable.Database, table.btable.Name)
+		log.Println(query)
+		if _, err := ch.conn.Exec(query); err != nil {
+			return err
+		}*/
+
+	}
+
+	return nil
+}
+
+// AttachPartitions - execute ATTACH command for specific table
+func (ch *ClickHouse) AttachPartitions(table BackupTable) error {
 	for _, partition := range table.Partitions {
 		query := fmt.Sprintf("ALTER TABLE `%s`.`%s` ATTACH PART '%s'", table.Database, table.Name, partition.Name)
 		log.Println(query)


### PR DESCRIPTION
When restoring with flashback, clickhouse-backup will : 
- remove from the database the data parts that were created since the backup.( new data are deleted)
- add from backup the data parts that do not longer exist in the database. (deleted data are restored).

Instead of dropping db or table before restoring all the data, the "flashback" restore only manages the data that have been changed since the backup.  This could save disk and network IO, especially in a replicated configuration.
 