### PR TITLE
when downloading backups, avoid creating local backup dir before conf…

### DIFF
--- a/pkg/storage/general.go
+++ b/pkg/storage/general.go
@@ -150,9 +150,6 @@ func (bd *BackupDestination) BackupList() ([]Backup, error) {
 }
 
 func (bd *BackupDestination) CompressedStreamDownload(remotePath string, localPath string) error {
-	if err := os.MkdirAll(localPath, os.ModePerm); err != nil {
-		return err
-	}
 	archiveName := path.Join(bd.path, fmt.Sprintf("%s.%s", remotePath, getExtension(bd.compressionFormat)))
 	if err := bd.Connect(); err != nil {
 		return err


### PR DESCRIPTION
…irming it exists remotely

This is causing trying to download non-existing backups to create empty/fake local backups. So any typo in the name or any error will create an invalid backup entry.

It will still be created below as part of: `os.MkdirAll(extractDir, os.ModePerm)`