### PR TITLE
fix passing proxy config 

### DIFF
--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -54,6 +54,7 @@ func (s *S3) Connect() error {
 	if s.Config.DisableCertVerification {
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			Proxy:           http.ProxyFromEnvironment,
 		}
 		awsConfig.HTTPClient = &http.Client{Transport: tr}
 	}


### PR DESCRIPTION
Fixes passing proxy config via env variables when using config with disabled TLS certificate verification.

Fixes #178