### PR TITLE
[clickhouse-backup] Fix for downloading folders from GCS

### DIFF
--- a/pkg/backup/download.go
+++ b/pkg/backup/download.go
@@ -71,7 +71,7 @@ func (b *Backuper) Download(backupName string, tablePattern string, schemaOnly b
 	if err := b.init(); err != nil {
 		return err
 	}
-	remoteBackups, err := b.dst.BackupList()
+	remoteBackups, err := b.dst.BackupFolderList(backupName)
 	if err != nil {
 		return err
 	}

--- a/pkg/backup/download.go
+++ b/pkg/backup/download.go
@@ -71,7 +71,9 @@ func (b *Backuper) Download(backupName string, tablePattern string, schemaOnly b
 	if err := b.init(); err != nil {
 		return err
 	}
-	remoteBackups, err := b.dst.BackupFolderList(backupName)
+
+	// fix for gcs
+	remoteBackups, err := b.dst.BackupFolderList(backupName, b.cfg.General.RemoteStorage)
 	if err != nil {
 		return err
 	}

--- a/pkg/new_storage/gcs.go
+++ b/pkg/new_storage/gcs.go
@@ -44,12 +44,12 @@ func (gcs *GCS) Connect() error {
 
 func (gcs *GCS) Walk(gcsPath string, recursive bool, process func(r RemoteFile) error) error {
 	ctx := context.Background()
-	delimiter := ""
+	delimiter := "/"
 	if !recursive {
 		delimiter = "/"
 	}
 	it := gcs.client.Bucket(gcs.Config.Bucket).Objects(ctx, &storage.Query{
-		Prefix:    path.Join(gcs.Config.Path, gcsPath) + "/",
+		Prefix:    gcsPath,
 		Delimiter: delimiter,
 	})
 	for {
@@ -58,7 +58,7 @@ func (gcs *GCS) Walk(gcsPath string, recursive bool, process func(r RemoteFile) 
 		case nil:
 			if object.Prefix != "" {
 				if err := process(&gcsFile{
-					name: strings.TrimPrefix(object.Prefix, path.Join(gcs.Config.Path, gcsPath)),
+					name: strings.TrimPrefix(object.Prefix, path.Join(gcs.Config.Path, "/")),
 				}); err != nil {
 					return err
 				}
@@ -67,7 +67,7 @@ func (gcs *GCS) Walk(gcsPath string, recursive bool, process func(r RemoteFile) 
 			if err := process(&gcsFile{
 				size:         object.Size,
 				lastModified: object.Updated,
-				name:         strings.TrimPrefix(object.Name, path.Join(gcs.Config.Path, gcsPath)),
+				name:         strings.TrimPrefix(object.Name, path.Join(gcs.Config.Path, "/")),
 			}); err != nil {
 				return err
 			}

--- a/pkg/new_storage/general.go
+++ b/pkg/new_storage/general.go
@@ -172,12 +172,12 @@ func (bd *BackupDestination) BackupList() ([]Backup, error) {
 }
 
 // use this function only for gcs
-func (bd *BackupDestination) BackupFolderList(backupName string, remoteStorage string) ([]Backup, error) {
+func (bd *BackupDestination) BackupFolderList(backupFolderName string, remoteStorage string) ([]Backup, error) {
 	if remoteStorage != "gcs" {
 		return bd.BackupList()
 	}
 	result := []Backup{}
-	err := bd.Walk(backupName, false, func(o RemoteFile) error {
+	err := bd.Walk(backupFolderName, false, func(o RemoteFile) error {
 		// Legacy backup
 		if ok, backupName, fileExtension := isLegacyBackup(strings.TrimPrefix(o.Name(), "/")); ok {
 			result = append(result, Backup{

--- a/pkg/new_storage/general.go
+++ b/pkg/new_storage/general.go
@@ -171,7 +171,11 @@ func (bd *BackupDestination) BackupList() ([]Backup, error) {
 	return result, err
 }
 
-func (bd *BackupDestination) BackupFolderList(backupName string) ([]Backup, error) {
+// use this function only for gcs
+func (bd *BackupDestination) BackupFolderList(backupName string, remoteStorage string) ([]Backup, error) {
+	if remoteStorage != "gcs" {
+		return bd.BackupList()
+	}
 	result := []Backup{}
 	err := bd.Walk(backupName, false, func(o RemoteFile) error {
 		// Legacy backup


### PR DESCRIPTION
## summary

Downloading folders from GCS seems to be not working, while the same works for create and upload works.  

## testing

- without the fix
```
2021/07/13 19:07:51 debug SELECT value FROM `system`.`build_options` where name='VERSION_INTEGER'
2021/07/13 19:07:51 debug SELECT * FROM system.disks;
2021/07/13 19:07:52 debug SELECT value FROM `system`.`build_options` where name='VERSION_INTEGER'
2021/07/13 19:07:52 debug SELECT * FROM system.disks;
2021/07/13 19:07:52 debug SELECT value FROM `system`.`build_options` where name='VERSION_INTEGER'
2021/07/13 19:07:52 debug SELECT * FROM system.disks;
2021/07/13 19:07:52 error 'INCR_ch-cdnvideolog-1-1_default.enriched_video_access_log_records_20210711_0400' is not found on remote storage
```

- with the fix
```
2021/07/13 19:08:33 debug SELECT value FROM `system`.`build_options` where name='VERSION_INTEGER'
2021/07/13 19:08:33 debug SELECT * FROM system.disks;
2021/07/13 19:08:33 debug SELECT value FROM `system`.`build_options` where name='VERSION_INTEGER'
2021/07/13 19:08:33 debug SELECT * FROM system.disks;
2021/07/13 19:08:33 debug SELECT value FROM `system`.`build_options` where name='VERSION_INTEGER'
2021/07/13 19:08:33 debug SELECT * FROM system.disks;
2021/07/13 19:08:34 debug SELECT value FROM `system`.`build_options` where name='VERSION_INTEGER'
2021/07/13 19:08:34 debug SELECT * FROM system.disks;
2021/07/13 19:08:34 debug SELECT value FROM `system`.`build_options` where name='VERSION_INTEGER'
2021/07/13 19:08:34 debug SELECT * FROM system.disks;
2021/07/13 19:08:34 debug SELECT value FROM `system`.`build_options` where name='VERSION_INTEGER'
2021/07/13 19:08:34 debug SELECT * FROM system.disks;
2021/07/13 19:08:34 debug SELECT value FROM `system`.`build_options` where name='VERSION_INTEGER'
2021/07/13 19:08:34 debug SELECT * FROM system.disks;
2021/07/13 19:08:34 debug SELECT value FROM `system`.`build_options` where name='VERSION_INTEGER'
2021/07/13 19:08:34 debug SELECT * FROM system.disks;
2021/07/13 19:08:34 debug SELECT value FROM `system`.`build_options` where name='VERSION_INTEGER'
2021/07/13 19:08:34 debug SELECT * FROM system.disks;
2021/07/13 19:08:34 debug FULL_ch-cdnvideolog-1-1_default.enriched_video_access_log_records_20210709_0400/metadata/default/enriched_video_access_log_records.json backup=FULL_ch-cdnvideolog-1-1_default.enriched_video_access_log_records_20210709_0400
operation=download table=default.enriched_video_access_log_records
2021/07/13 19:08:34  info done                      backup=FULL_ch-cdnvideolog-1-1_default.enriched_video_access_log_records_20210709_0400 operation=download table=default.enriched_video_access_log_records
2021/07/13 19:10:12  info done                      backup=FULL_ch-cdnvideolog-1-1_default.enriched_video_access_log_records_20210709_0400 duration=1m37.917s operation=download size=13.03GiB table=default.enriched_video_access_log_records0.00% 1m37s
2021/07/13 19:10:12  info done                      backup=FULL_ch-cdnvideolog-1-1_default.enriched_video_access_log_records_20210709_0400 duration=1m38.378s operation=download size=13.03GiB
2021/07/13 19:10:12 debug INCR_ch-cdnvideolog-1-1_default.enriched_video_access_log_records_20210710_0400/metadata/default/enriched_video_access_log_records.json backup=INCR_ch-cdnvideolog-1-1_default.enriched_video_access_log_records_20210710_0400
operation=download table=default.enriched_video_access_log_records
2021/07/13 19:10:12  info done                      backup=INCR_ch-cdnvideolog-1-1_default.enriched_video_access_log_records_20210710_0400 operation=download table=default.enriched_video_access_log_records
2021/07/13 19:10:16  info done                      backup=INCR_ch-cdnvideolog-1-1_default.enriched_video_access_log_records_20210710_0400 duration=3.49s operation=download size=13.05GiB table=default.enriched_video_access_log_records===] 100.00% 0s
2021/07/13 19:10:16  info done                      backup=INCR_ch-cdnvideolog-1-1_default.enriched_video_access_log_records_20210710_0400 duration=1m42.412s operation=download size=13.05GiB
2021/07/13 19:10:16 debug INCR_ch-cdnvideolog-1-1_default.enriched_video_access_log_records_20210711_0400/metadata/default/enriched_video_access_log_records.json backup=INCR_ch-cdnvideolog-1-1_default.enriched_video_access_log_records_20210711_0400
operation=download table=default.enriched_video_access_log_records
2021/07/13 19:10:16  info done                      backup=INCR_ch-cdnvideolog-1-1_default.enriched_video_access_log_records_20210711_0400 operation=download table=default.enriched_video_access_log_records
2021/07/13 19:10:19  info done                      backup=INCR_ch-cdnvideolog-1-1_default.enriched_video_access_log_records_20210711_0400 duration=2.926s operation=download size=13.06GiB table=default.enriched_video_access_log_records==] 100.00% 0s
2021/07/13 19:10:19  info done                      backup=INCR_ch-cdnvideolog-1-1_default.enriched_video_access_log_records_20210711_0400 duration=1m45.927s operation=download size=13.06GiB
```