### PR TITLE
Remove unused skip_sync_replica_timeouts option

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -114,7 +114,6 @@ clickhouse:
   secure: false                    # CLICKHOUSE_SECURE
   skip_verify: false               # CLICKHOUSE_SKIP_VERIFY
   sync_replicated_tables: true     # CLICKHOUSE_SYNC_REPLICATED_TABLES
-  skip_sync_replica_timeouts: true # CLICKHOUSE_SKIP_SYNC_REPLICA_TIMEOUTS
   log_sql_queries: true            # CLICKHOUSE_LOG_SQL_QUERIES
 azblob:
   endpoint_suffix: "core.windows.net" # AZBLOB_ENDPOINT_SUFFIX

--- a/config/config.go
+++ b/config/config.go
@@ -129,19 +129,18 @@ type SFTPConfig struct {
 
 // ClickHouseConfig - clickhouse settings section
 type ClickHouseConfig struct {
-	Username                string            `yaml:"username" envconfig:"CLICKHOUSE_USERNAME"`
-	Password                string            `yaml:"password" envconfig:"CLICKHOUSE_PASSWORD"`
-	Host                    string            `yaml:"host" envconfig:"CLICKHOUSE_HOST"`
-	Port                    uint              `yaml:"port" envconfig:"CLICKHOUSE_PORT"`
-	DiskMapping             map[string]string `yaml:"disk_mapping" envconfig:"CLICKHOUSE_DISK_MAPPING"`
-	SkipTables              []string          `yaml:"skip_tables" envconfig:"CLICKHOUSE_SKIP_TABLES"`
-	Timeout                 string            `yaml:"timeout" envconfig:"CLICKHOUSE_TIMEOUT"`
-	FreezeByPart            bool              `yaml:"freeze_by_part" envconfig:"CLICKHOUSE_FREEZE_BY_PART"`
-	Secure                  bool              `yaml:"secure" envconfig:"CLICKHOUSE_SECURE"`
-	SkipVerify              bool              `yaml:"skip_verify" envconfig:"CLICKHOUSE_SKIP_VERIFY"`
-	SyncReplicatedTables    bool              `yaml:"sync_replicated_tables" envconfig:"CLICKHOUSE_SYNC_REPLICATED_TABLES"`
-	SkipSyncReplicaTimeouts bool              `yaml:"skip_sync_replica_timeouts" envconfig:"CLICKHOUSE_SKIP_SYNC_REPLICA_TIMEOUTS"`
-	LogSQLQueries           bool              `yaml:"log_sql_queries" envconfig:"CLICKHOUSE_LOG_SQL_QUERIES"`
+	Username             string            `yaml:"username" envconfig:"CLICKHOUSE_USERNAME"`
+	Password             string            `yaml:"password" envconfig:"CLICKHOUSE_PASSWORD"`
+	Host                 string            `yaml:"host" envconfig:"CLICKHOUSE_HOST"`
+	Port                 uint              `yaml:"port" envconfig:"CLICKHOUSE_PORT"`
+	DiskMapping          map[string]string `yaml:"disk_mapping" envconfig:"CLICKHOUSE_DISK_MAPPING"`
+	SkipTables           []string          `yaml:"skip_tables" envconfig:"CLICKHOUSE_SKIP_TABLES"`
+	Timeout              string            `yaml:"timeout" envconfig:"CLICKHOUSE_TIMEOUT"`
+	FreezeByPart         bool              `yaml:"freeze_by_part" envconfig:"CLICKHOUSE_FREEZE_BY_PART"`
+	Secure               bool              `yaml:"secure" envconfig:"CLICKHOUSE_SECURE"`
+	SkipVerify           bool              `yaml:"skip_verify" envconfig:"CLICKHOUSE_SKIP_VERIFY"`
+	SyncReplicatedTables bool              `yaml:"sync_replicated_tables" envconfig:"CLICKHOUSE_SYNC_REPLICATED_TABLES"`
+	LogSQLQueries        bool              `yaml:"log_sql_queries" envconfig:"CLICKHOUSE_LOG_SQL_QUERIES"`
 }
 
 type APIConfig struct {
@@ -279,10 +278,9 @@ func DefaultConfig() *Config {
 			SkipTables: []string{
 				"system.*",
 			},
-			Timeout:                 "5m",
-			SyncReplicatedTables:    true,
-			SkipSyncReplicaTimeouts: true,
-			LogSQLQueries:           false,
+			Timeout:              "5m",
+			SyncReplicatedTables: true,
+			LogSQLQueries:        false,
 		},
 		AzureBlob: AzureBlobConfig{
 			EndpointSuffix:    "core.windows.net",


### PR DESCRIPTION
The option is never used in the code. It already didn't do anything in the commit it was introduced in:
https://github.com/AlexAkulov/clickhouse-backup/commit/756ceacdd2a7840d96b83e06f3583c9d755b74c8