### PR TITLE
add S3_DEBUG option to allow debug S3 requests

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -147,6 +147,7 @@ s3:
   sse: AES256                      # S3_SSE
   disable_cert_verification: false # S3_DISABLE_CERT_VERIFICATION
   storage_class: STANDARD          # S3_STORAGE_CLASS
+  debug: false                     # S3_DEBUG
 gcs:
   credentials_file: ""         # GCS_CREDENTIALS_FILE
   credentials_json: ""         # GCS_CREDENTIALS_JSON

--- a/config/config.go
+++ b/config/config.go
@@ -91,6 +91,7 @@ type S3Config struct {
 	DisableCertVerification bool   `yaml:"disable_cert_verification" envconfig:"S3_DISABLE_CERT_VERIFICATION"`
 	StorageClass            string `yaml:"storage_class" envconfig:"S3_STORAGE_CLASS"`
 	Concurrency             int    `yaml:"concurrency" envconfig:"S3_CONCURRENCY"`
+	Debug                   bool   `yaml:"debug" envconfig:"S3_DEBUG"`
 }
 
 // COSConfig - cos settings section

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       SSH_ENABLE_PASSWORD_AUTH: "true"
     command: sh -c 'echo "PermitRootLogin yes" >> /etc/ssh/sshd_config && echo "root:JFzMHfVpvTgEd74XXPq6wARA2Qg3AutJ" | chpasswd && /usr/sbin/sshd -D -e -f /etc/ssh/sshd_config'
     ports:
-      - 22:22
+      - "2222:22"
     networks:
       - clickhouse-backup
 
@@ -21,7 +21,7 @@ services:
     entrypoint: sh
     command: -c 'mkdir -p doc_gen_minio/export/clickhouse && minio server doc_gen_minio/export'
     ports:
-      - 9010:9000
+      - "9010:9000"
     networks:
       - clickhouse-backup
 
@@ -38,6 +38,7 @@ services:
     environment:
       TZ: UTC
       LOG_LEVEL: ${LOG_LEVEL:-info}
+      S3_DEBUG: ${S3_DEBUG:-false}
     volumes:
       - ./backup-user.xml:/etc/clickhouse-server/users.d/backup-user.xml
       - ${CLICKHOUSE_BACKUP_BIN:-../../clickhouse-backup/clickhouse-backup}:/usr/bin/clickhouse-backup
@@ -48,9 +49,9 @@ services:
       - ./ssl.xml:/etc/clickhouse-server/config.d/ssl.xml
       - ./cluster.xml:/etc/clickhouse-server/config.d/cluster.xml
     ports:
-      - 8123:8123
-      - 9000:9000
-      - 7171:7171
+      - "8123:8123"
+      - "9000:9000"
+      - "7171:7171"
     networks:
       - clickhouse-backup
     depends_on:

--- a/test/integration/docker-compose_advanced.yml
+++ b/test/integration/docker-compose_advanced.yml
@@ -8,7 +8,7 @@ services:
       SSH_ENABLE_PASSWORD_AUTH: "true"
     command: sh -c 'echo "PermitRootLogin yes" >> /etc/ssh/sshd_config && echo "root:JFzMHfVpvTgEd74XXPq6wARA2Qg3AutJ" | chpasswd && /usr/sbin/sshd -D -e -f /etc/ssh/sshd_config'
     ports:
-      - 22:22
+      - "2222:22"
     networks:
       - clickhouse-backup
 
@@ -21,7 +21,7 @@ services:
     entrypoint: sh
     command: -c 'mkdir -p doc_gen_minio/export/clickhouse && minio server doc_gen_minio/export'
     ports:
-      - 9010:9000
+      - "9010:9000"
     networks:
       - clickhouse-backup
 
@@ -32,7 +32,7 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: "root"
     ports:
-      - 3306:3306
+      - "3306:3306"
     networks:
       - clickhouse-backup
 
@@ -49,6 +49,7 @@ services:
     environment:
       TZ: UTC
       LOG_LEVEL: ${LOG_LEVEL:-info}
+      S3_DEBUG: ${S3_DEBUG:-false}
     volumes:
       - ./backup-user.xml:/etc/clickhouse-server/users.d/backup-user.xml
       - ./enable-access_management.xml:/etc/clickhouse-server/users.d/enable-access_management.xml
@@ -63,9 +64,9 @@ services:
       # uncomment only for local debug
       # - ./clickhouse-server.log:/var/log/clickhouse-server/clickhouse-server.log
     ports:
-      - 8123:8123
-      - 9000:9000
-      - 7171:7171
+      - "8123:8123"
+      - "9000:9000"
+      - "7171:7171"
     networks:
       - clickhouse-backup
     depends_on:

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -2,9 +2,12 @@
 set -x
 set -e
 
+export CLICKHOUSE_VERSION=${CLICKHOUSE_VERSION:-20.3}
 export CLICKHOUSE_BACKUP_BIN="$(pwd)/clickhouse-backup/clickhouse-backup"
 export LOG_LEVEL=${LOG_LEVEL:-info}
-export CLICKHOUSE_VERSION=${CLICKHOUSE_VERSION:-20.3}
+export GCS_TESTS=${GCS_TESTS:-}
+export AZURE_TESTS=${AZURE_TESTS:-}
+export S3_DEBUG=${S3_DEBUG:-false}
 
 if [[ "${CLICKHOUSE_VERSION}" == 2* ]]; then
   export COMPOSE_FILE=docker-compose_advanced.yml
@@ -17,6 +20,4 @@ docker volume prune -f
 make clean
 make build
 docker-compose -f test/integration/${COMPOSE_FILE} up -d --force-recreate
-# To run integration tests including GCS tests set GCS_TESTS environment variable:
-# GCS_TESTS=true go test -tags=integration -v test/integration/integration_test.go
 go test  -timeout 30m -failfast -tags=integration -run "${RUN_TESTS:-.+}" -v test/integration/integration_test.go


### PR DESCRIPTION
add S3_DEBUG option to allow debug https://github.com/AlexAkulov/clickhouse-backup/issues/240

fix some linter suggestion for docker-compose, ports - 22:22 interprets as numeric instead of string and can conflict with current sshd