### PR TITLE
[clickhouse-backup] Set read timeout for large datasets

### DIFF
--- a/pkg/clickhouse/clickhouse.go
+++ b/pkg/clickhouse/clickhouse.go
@@ -42,6 +42,7 @@ func (ch *ClickHouse) Connect() error {
 	params.Add("username", ch.Config.Username)
 	params.Add("password", ch.Config.Password)
 	params.Add("database", "system")
+	params.Add("read_timeout", timeoutSeconds)
 	params.Add("receive_timeout", timeoutSeconds)
 	params.Add("send_timeout", timeoutSeconds)
 	if ch.Config.Secure {


### PR DESCRIPTION
## summary

For large datasets a read_timeout needs to be set in the database connect string.  This is helpful for `alter table freeze` to work in particular.

## issue

More here:
[244](https://github.com/AlexAkulov/clickhouse-backup/issues/244)