### PR TITLE
Fix restore command failure

### DIFF
--- a/pkg/clickhouse/utils.go
+++ b/pkg/clickhouse/utils.go
@@ -9,12 +9,26 @@ import (
 )
 
 func GetDiskByPath(disks []Disk, dataPath string) string {
+	prefixLengthMap := map[int]string{}
+
 	for _, disk := range disks {
 		if strings.HasPrefix(dataPath, disk.Path) {
-			return disk.Name
+			prefixLengthMap[len(disk.Path)] = disk.Name
 		}
 	}
-	return "unknown"
+
+	if len(prefixLengthMap) == 0 {
+		return "unknown"
+	}
+
+	var maxPrefixLength int
+	for prefixLength := range prefixLengthMap {
+		if prefixLength > maxPrefixLength {
+			maxPrefixLength = prefixLength
+		}
+	}
+
+	return prefixLengthMap[maxPrefixLength]
 }
 
 func GetDisksByPaths(disks []Disk, dataPaths []string) map[string]string {


### PR DESCRIPTION
I used s3 for data storage and faced with `restore` command failure.  When I tried to restore my backup I received the next error  ```error can't attach partitions for table 'default.s3_table': code: 233, message: Detached part "all_1_1_0" not found```

Server's config related to data storage:
```yaml
storage_configuration:
    # S3 Credentials
    disks:
        s3:
            type: s3
            endpoint: https://my-end-point.s3.us-east-1.amazonaws.com/   
    policies:
        s3only:
            volumes:
                main:
                    disk: s3
```

The thing is that by default s3 disk will have the next paths:
**metadata_path** - ```/var/lib/clickhouse/disks/s3/```
**cache_path** - ```/var/lib/clickhouse/disks/s3/cache/```
etc.

As you see above you will have two disks:
```'default'``` - with path - ```/var/lib/clickhouse/```
```'s3'``` - with path - ```/var/lib/clickhouse/disks/s3/```

And the thing is that ```s3``` path is inside ```default``` disk path. And unfortunately **GetDiskByPath** returns the first disk name with a prefix that matches to the input path. In my case it's ```default``` instead of ```s3```.  And then everything go wrong. 
So basically I fixed that error and now the function correctly determines the disk. 