### PR TITLE
Support of ManagedIdentity azure auth

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -126,6 +126,7 @@ azblob:
   account_name: ""             # AZBLOB_ACCOUNT_NAME
   account_key: ""              # AZBLOB_ACCOUNT_KEY
   sas: ""                      # AZBLOB_SAS
+  use_managed_identity: false  # AZBLOB_USE_MANAGED_IDENTITY
   container: ""                # AZBLOB_CONTAINER
   path: ""                     # AZBLOB_PATH
   compression_level: 1         # AZBLOB_COMPRESSION_LEVEL

--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,7 @@ type AzureBlobConfig struct {
 	AccountName           string `yaml:"account_name" envconfig:"AZBLOB_ACCOUNT_NAME"`
 	AccountKey            string `yaml:"account_key" envconfig:"AZBLOB_ACCOUNT_KEY"`
 	SharedAccessSignature string `yaml:"sas" envconfig:"AZBLOB_SAS"`
+	UseManagedIdentity    bool   `yaml:"use_managed_identity" envconfig:"AZBLOB_USE_MANAGED_IDENTITY"`
 	Container             string `yaml:"container" envconfig:"AZBLOB_CONTAINER"`
 	Path                  string `yaml:"path" envconfig:"AZBLOB_PATH"`
 	CompressionLevel      int    `yaml:"compression_level" envconfig:"AZBLOB_COMPRESSION_LEVEL"`

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ require (
 	cloud.google.com/go/storage v1.16.0
 	github.com/Azure/azure-pipeline-go v0.2.2
 	github.com/Azure/azure-storage-blob-go v0.10.1-0.20200807102407-24fe552e0870
+	github.com/Azure/go-autorest/autorest v0.9.0
+	github.com/Azure/go-autorest/autorest/adal v0.8.3
 	github.com/ClickHouse/clickhouse-go v1.4.7
 	github.com/apex/log v1.9.0
 	github.com/aws/aws-sdk-go v1.40.31

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,7 @@ github.com/Azure/go-autorest/autorest/date v0.2.0 h1:yW+Zlqf26583pE43KhfnhFcdmSW
 github.com/Azure/go-autorest/autorest/date v0.2.0/go.mod h1:vcORJHLJEh643/Ioh9+vPmf1Ij9AEBM5FuBIXLmIy0g=
 github.com/Azure/go-autorest/autorest/mocks v0.1.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
 github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
+github.com/Azure/go-autorest/autorest/mocks v0.3.0 h1:qJumjCaCudz+OcqE9/XtEPfvtOjOmKaui4EOpFI6zZc=
 github.com/Azure/go-autorest/autorest/mocks v0.3.0/go.mod h1:a8FDP3DYzQ4RYfVAxAN3SVSiiO77gL2j2ronKKP0syM=
 github.com/Azure/go-autorest/logger v0.1.0 h1:ruG4BSDXONFRrZZJ2GUXDiUyVpayPmb1GnWeHDdaNKY=
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=

--- a/pkg/new_storage/azblob.go
+++ b/pkg/new_storage/azblob.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-storage-blob-go/azblob"
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/pkg/errors"
 )
 
@@ -38,8 +40,8 @@ func (s *AzureBlob) Connect() error {
 	if s.Config.AccountName == "" {
 		return fmt.Errorf("account name not set")
 	}
-	if s.Config.AccountKey == "" && s.Config.SharedAccessSignature == "" {
-		return fmt.Errorf("account key or SAS must be set")
+	if s.Config.AccountKey == "" && s.Config.SharedAccessSignature == "" && !s.Config.UseManagedIdentity {
+		return fmt.Errorf("account key or SAS or use_managed_identity must be set")
 	}
 	var (
 		err        error
@@ -52,10 +54,39 @@ func (s *AzureBlob) Connect() error {
 			return err
 		}
 		urlString = fmt.Sprintf("https://%s.blob.%s", s.Config.AccountName, s.Config.EndpointSuffix)
-	}
-	if s.Config.SharedAccessSignature != "" {
+	} else if s.Config.SharedAccessSignature != "" {
 		credential = azblob.NewAnonymousCredential()
 		urlString = fmt.Sprintf("https://%s.blob.%s?%s", s.Config.AccountName, s.Config.EndpointSuffix, s.Config.SharedAccessSignature)
+	} else if s.Config.UseManagedIdentity {
+		azureEnv, err := azure.EnvironmentFromName("AZUREPUBLICCLOUD")
+		if err != nil {
+			return err
+		}
+		var spToken *adal.ServicePrincipalToken
+		msiEndpoint, _ := adal.GetMSIVMEndpoint()
+		spToken, err = adal.NewServicePrincipalTokenFromMSI(msiEndpoint, azureEnv.ResourceIdentifiers.Storage)
+		if err != nil {
+			return err
+		}
+		tokenRefresher := func(tokenCred azblob.TokenCredential) time.Duration {
+			// Refreshing Azure auth token
+			err := spToken.Refresh()
+			if err != nil {
+				// Error refreshing Azure auth token, retry after 1 min.
+				return 1 * time.Minute
+			}
+			token := spToken.Token()
+			tokenCred.SetToken(token.AccessToken)
+			// Return the expiry time of <response> minus 30 min. so we can retry
+			// OAuth token is valid for 1hr.
+			// ManagedIdentity one for 24 hrs.
+			exp := token.Expires().Sub(time.Now().Add(30 * time.Minute))
+			// Received a new Azure auth token, valid for exp
+			return exp
+		}
+
+		credential = azblob.NewTokenCredential("", tokenRefresher)
+		urlString = fmt.Sprintf("https://%s.blob.%s", s.Config.AccountName, s.Config.EndpointSuffix)
 	}
 
 	u, err := url.Parse(urlString)


### PR DESCRIPTION
First of all, thanks for such a great tool!

We are using this tool with both AWS S3 and Azure blob storage.

AWS S3 works ok with IAM Instance Role permissions associated with an instance, w/o using any static keys.

However, with Azure the tool only works with Storage Account access keys (not really secure method, providing full access to SA, the keys are static and so on) or SAS tokens (which are not flexible to use and insecure the way Azure implemented them).

There are 2 other methods to access Azure blob storage: OAuth credentials of AD app registrations (tenant id + app id + client secret token) or using ManagedIdentity. 

The last one is nice because it can work with SystemAssigned Identity associated with a VM, much like Instance Role with AWS. You can grant an access to a specific container within Storage Account to a service principal of a single VM without using any kind of credentials or static keys.

Adding this simple PR to be able to use ManagedIdentity. Just grant access and set "use_managed_identity: true".