### PR TITLE
S3_PART_SIZE config option

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -149,6 +149,8 @@ s3:
   sse: AES256                      # S3_SSE
   disable_cert_verification: false # S3_DISABLE_CERT_VERIFICATION
   storage_class: STANDARD          # S3_STORAGE_CLASS
+  # if less or eq 0 then calculated as max_file_size / 10000 
+  part_size: 0                     # S3_PART_SIZE
   debug: false                     # S3_DEBUG
 gcs:
   credentials_file: ""         # GCS_CREDENTIALS_FILE

--- a/config/config.go
+++ b/config/config.go
@@ -82,6 +82,7 @@ type S3Config struct {
 	DisableCertVerification bool   `yaml:"disable_cert_verification" envconfig:"S3_DISABLE_CERT_VERIFICATION"`
 	StorageClass            string `yaml:"storage_class" envconfig:"S3_STORAGE_CLASS"`
 	Concurrency             int    `yaml:"concurrency" envconfig:"S3_CONCURRENCY"`
+	PartSize                int64  `yaml:"part_size" envconfig:"S3_PART_SIZE"`
 	Debug                   bool   `yaml:"debug" envconfig:"S3_DEBUG"`
 }
 
@@ -316,6 +317,7 @@ func DefaultConfig() *Config {
 			DisableCertVerification: false,
 			StorageClass:            s3.StorageClassStandard,
 			Concurrency:             1,
+			PartSize:                0,
 		},
 		GCS: GCSConfig{
 			CompressionLevel:  1,

--- a/pkg/new_storage/general.go
+++ b/pkg/new_storage/general.go
@@ -403,9 +403,12 @@ func NewBackupDestination(cfg *config.Config) (*BackupDestination, error) {
 			cfg.General.DisableProgressBar,
 		}, nil
 	case "s3":
-		partSize := cfg.General.MaxFileSize / 10000
-		if partSize < 5242880 {
-			partSize = 5242880
+		partSize := cfg.S3.PartSize
+		if cfg.S3.PartSize <= 0 {
+			partSize = cfg.General.MaxFileSize / 10000
+			if partSize < 5242880 {
+				partSize = 5242880
+			}
 		}
 		s3Storage := &S3{
 			Config:      &cfg.S3,


### PR DESCRIPTION
**REALTED**
Issue #273

**PROBLEM**
I'am using MinIO as S3 object storage for ClickHouse backups, and I can't upload big parts to it, because of it "Maximum number of parts per upload" limit (https://docs.min.io/docs/minio-server-limits-per-tenant.html). I've got the following lines from log file:

**LOG**
`-----------------------------------------------------
2021/09/30 06:20:02  info DEBUG: Request s3/UploadPart Details:
---[ REQUEST POST-SIGN ]-----------------------------
PUT /PATH?partNumber=10000&uploadId=d0a6d3b1-e2ce-4a12-912c-65ad69727ba9 HTTP/1.1
Host: 100.100.100.100:9000
User-Agent: aws-sdk-go/1.40.31 (go1.16.7; linux; amd64) S3Manager
Content-Length: 10737418
Authorization: AWS4-HMAC-SHA256 Credential=clickhouse_backup/20210930/us-east-1/s3/aws4_request, SignedHeaders=content-length;content-md5;host;x-amz-content-sha256;x-amz-date, Signature=cc81e19deed144659ae2cb5dd6b9acadb8516aae5a331f58e644e4ea5c8e7aa2
Content-Md5: wouhtJAHBQ+phEjQYmqVng==
Expect: 100-Continue
X-Amz-Content-Sha256: c13d660237fb3f3362c26888da1e26fb2208f266d33d0b0dd76c0d75067f3513
X-Amz-Date: 20210930T062002Z
Accept-Encoding: gzip


-----------------------------------------------------
2021/09/30 06:20:02  info DEBUG: Response s3/UploadPart Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Content-Length: 0
Accept-Ranges: bytes
Content-Security-Policy: block-all-mixed-content
Date: Thu, 30 Sep 2021 06:20:02 GMT
Etag: "c28ba1b49007050fa98448d0626a959e"
Server: MinIO
Strict-Transport-Security: max-age=31536000; includeSubDomains
Vary: Origin
Vary: Accept-Encoding
X-Amz-Request-Id: 16A9853508EA0DD9
X-Content-Type-Options: nosniff
X-Xss-Protection: 1; mode=block


-----------------------------------------------------
2021/09/30 06:20:02  info DEBUG: Request s3/AbortMultipartUpload Details:
---[ REQUEST POST-SIGN ]-----------------------------
DELETE /PATH/default_2.tar?uploadId=d0a6d3b1-e2ce-4a12-912c-65ad69727ba9 HTTP/1.1
Host: 100.100.100.100:9000
User-Agent: aws-sdk-go/1.40.31 (go1.16.7; linux; amd64) S3Manager
Authorization: AWS4-HMAC-SHA256 Credential=clickhouse_backup/20210930/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=24a505afe1bc5f3cac70dbbd7c96e7b4eb77a243e20e152401ab9f90aff77b0b
X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
X-Amz-Date: 20210930T062002Z
Accept-Encoding: gzip


-----------------------------------------------------
2021/09/30 06:20:12  info DEBUG: Response s3/AbortMultipartUpload Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 204 No Content
Accept-Ranges: bytes
Content-Security-Policy: block-all-mixed-content
Date: Thu, 30 Sep 2021 06:20:12 GMT
Server: MinIO
Strict-Transport-Security: max-age=31536000; includeSubDomains
Vary: Origin
Vary: Accept-Encoding
X-Amz-Request-Id: 16A985350E766F62
X-Content-Type-Options: nosniff
X-Xss-Protection: 1; mode=block


-----------------------------------------------------`

