### PR TITLE
Release 1.2.2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,6 +74,7 @@ jobs:
           path: |
             test/integration/credentials.json
           if-no-files-found: error
+          retention-days: 1
         if: |
           steps.secrets.outputs.GCS_TESTS == 'true'
 
@@ -85,6 +86,8 @@ jobs:
             ./clickhouse-backup/clickhouse-backup-race
             ChangeLog.md
           if-no-files-found: error
+          retention-days: 1
+
   test:
     needs: build
     name: Test
@@ -156,6 +159,10 @@ jobs:
           docker-compose -f test/integration/${COMPOSE_FILE} ps -a
           go test -timeout 30m -failfast -tags=integration -run "${RUN_TESTS:-.+}" -v test/integration/integration_test.go
 
+      - uses: geekyeggo/delete-artifact@v1
+        with:
+          name: build-gcp-credentials
+
   docker:
     needs: test
     name: Docker
@@ -192,3 +199,9 @@ jobs:
             docker image tag ${DOCKER_IMAGE}:${DOCKER_TAG} ${DOCKER_REGISTRY}/${DOCKER_REPO}/${DOCKER_IMAGE}:${DOCKER_TAG}
             docker push ${DOCKER_REGISTRY}/${DOCKER_REPO}/${DOCKER_IMAGE}:${DOCKER_TAG}
           fi
+
+      - name: delete artifacts
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: build-artifacts
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -159,10 +159,6 @@ jobs:
           docker-compose -f test/integration/${COMPOSE_FILE} ps -a
           go test -timeout 30m -failfast -tags=integration -run "${RUN_TESTS:-.+}" -v test/integration/integration_test.go
 
-      - uses: geekyeggo/delete-artifact@v1
-        with:
-          name: build-gcp-credentials
-
   docker:
     needs: test
     name: Docker
@@ -200,8 +196,20 @@ jobs:
             docker push ${DOCKER_REGISTRY}/${DOCKER_REPO}/${DOCKER_IMAGE}:${DOCKER_TAG}
           fi
 
-      - name: delete artifacts
+  cleanup:
+    name: Cleanup
+    needs: docker
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: delete build-artifacts
         uses: geekyeggo/delete-artifact@v1
         with:
           name: build-artifacts
+          failOnError: false
 
+      - name: delete build-gcp-credentials
+        uses: geekyeggo/delete-artifact@v1
+        with:
+          name: build-gcp-credentials
+          failOnError: false

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ BUG FIXES
 - fix [#297](https://github.com/AlexAkulov/clickhouse-backup/issues/297), properly restore tables where have fields with the same name as table name
 - fix [#298](https://github.com/AlexAkulov/clickhouse-backup/issues/298), properly create `system.backup_actions` and `system.backup_list` integration tables for ClickHouse before 21.1
 - fix [#303](https://github.com/AlexAkulov/clickhouse-backup/issues/303), ignore leading and trailing spaces in `skip_tables` and `--tables` parameters
+- fix [#292](https://github.com/AlexAkulov/clickhouse-backup/issues/292), lock clickhouse connection pool to single connection
 
 # v1.2.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+# Upcoming Release change log
+
+BUG FIXES
+- fix [#297](https://github.com/AlexAkulov/clickhouse-backup/issues/297), properly restore tables where have fields with the same name as table name
+
 # v1.2.1
 
 IMPROVEMENTS

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 BUG FIXES
 - fix [#297](https://github.com/AlexAkulov/clickhouse-backup/issues/297), properly restore tables where have fields with the same name as table name
+- fix [#298](https://github.com/AlexAkulov/clickhouse-backup/issues/298), properly create `system.backup_actions` and `system.backup_list` integration tables for ClickHouse before 21.1
 
 # v1.2.1
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,9 +1,13 @@
-# Upcoming Release change log
+# v1.2.2
+
+IMPROVEMENTS
+- Add REST API `POST /backup/tables/all`, fix `POST /backup/tables` to respect `CLICKHOUSE_SKIP_TABLES`
 
 BUG FIXES
 - fix [#297](https://github.com/AlexAkulov/clickhouse-backup/issues/297), properly restore tables where have fields with the same name as table name
 - fix [#298](https://github.com/AlexAkulov/clickhouse-backup/issues/298), properly create `system.backup_actions` and `system.backup_list` integration tables for ClickHouse before 21.1
 - fix [#303](https://github.com/AlexAkulov/clickhouse-backup/issues/303), ignore leading and trailing spaces in `skip_tables` and `--tables` parameters
+
 # v1.2.1
 
 IMPROVEMENTS

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@
 BUG FIXES
 - fix [#297](https://github.com/AlexAkulov/clickhouse-backup/issues/297), properly restore tables where have fields with the same name as table name
 - fix [#298](https://github.com/AlexAkulov/clickhouse-backup/issues/298), properly create `system.backup_actions` and `system.backup_list` integration tables for ClickHouse before 21.1
-
+- fix [#303](https://github.com/AlexAkulov/clickhouse-backup/issues/303), ignore leading and trailing spaces in `skip_tables` and `--tables` parameters
 # v1.2.1
 
 IMPROVEMENTS

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -64,7 +64,7 @@ func filterTablesByPattern(tables []clickhouse.Table, tablePattern string) []cli
 	var result []clickhouse.Table
 	for _, t := range tables {
 		for _, pattern := range tablePatterns {
-			if matched, _ := filepath.Match(pattern, fmt.Sprintf("%s.%s", t.Database, t.Name)); matched {
+			if matched, _ := filepath.Match(strings.Trim(pattern, " \t\n\r"), fmt.Sprintf("%s.%s", t.Database, t.Name)); matched {
 				result = addTable(result, t)
 			}
 		}

--- a/pkg/backup/legacy.go
+++ b/pkg/backup/legacy.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/AlexAkulov/clickhouse-backup/pkg/clickhouse"
 	"github.com/AlexAkulov/clickhouse-backup/pkg/metadata"
 )
 
@@ -55,7 +54,7 @@ func parseSchemaPattern(metadataPath string, tablePattern string, dropTable bool
 		table, _ := url.PathUnescape(parts[1])
 		tableName := fmt.Sprintf("%s.%s", database, table)
 		for _, p := range tablePatterns {
-			if matched, _ := filepath.Match(p, tableName); !matched {
+			if matched, _ := filepath.Match(strings.Trim(p, " \t\r\n"), tableName); !matched {
 				continue
 			}
 			data, err := ioutil.ReadFile(filePath)
@@ -114,24 +113,6 @@ func getOrderByEngine(query string, dropTable bool) int64 {
 	return 0
 }
 
-func parseTablePatternForRestoreData(tables []metadata.TableMetadata, tablePattern string) clickhouse.BackupTables {
-	tablePatterns := []string{"*"}
-	if tablePattern != "" {
-		tablePatterns = strings.Split(tablePattern, ",")
-	}
-	result := clickhouse.BackupTables{}
-	for _, t := range tables {
-		for _, pattern := range tablePatterns {
-			tableName := fmt.Sprintf("%s.%s", t.Database, t.Table)
-			if matched, _ := filepath.Match(pattern, tableName); matched {
-				result = addBackupTable(result, t)
-			}
-		}
-	}
-	result.Sort()
-	return result
-}
-
 func parseTablePatternForDownload(tables []metadata.TableTitle, tablePattern string) []metadata.TableTitle {
 	tablePatterns := []string{"*"}
 	if tablePattern != "" {
@@ -141,7 +122,7 @@ func parseTablePatternForDownload(tables []metadata.TableTitle, tablePattern str
 	for _, t := range tables {
 		for _, pattern := range tablePatterns {
 			tableName := fmt.Sprintf("%s.%s", t.Database, t.Table)
-			if matched, _ := filepath.Match(pattern, tableName); matched {
+			if matched, _ := filepath.Match(strings.Trim(pattern, " \t\r\n"), tableName); matched {
 				result = append(result, t)
 				break
 			}

--- a/pkg/clickhouse/clickhouse.go
+++ b/pkg/clickhouse/clickhouse.go
@@ -178,7 +178,7 @@ func (ch *ClickHouse) GetTables(tablePattern string) ([]Table, error) {
 	}
 	for i, t := range tables {
 		for _, filter := range ch.Config.SkipTables {
-			if matched, _ := filepath.Match(filter, fmt.Sprintf("%s.%s", t.Database, t.Name)); matched {
+			if matched, _ := filepath.Match(strings.Trim(filter, " \t\r\n"), fmt.Sprintf("%s.%s", t.Database, t.Name)); matched {
 				t.Skip = true
 				break
 			}
@@ -232,7 +232,7 @@ func (ch *ClickHouse) prepareAllTablesSQL(tablePattern string, err error, skipDa
 
 	allTablesSQL += "  FROM system.tables WHERE is_temporary = 0"
 	if tablePattern != "" {
-		replacer := strings.NewReplacer(".", "\\.", ",", "|", "*", ".*", "?", ".")
+		replacer := strings.NewReplacer(".", "\\.", ",", "|", "*", ".*", "?", ".", " ", "")
 		allTablesSQL += fmt.Sprintf(" AND match(concat(database,'.',name),'%s') ", replacer.Replace(tablePattern))
 	}
 	if len(skipDatabases) > 0 {

--- a/pkg/clickhouse/clickhouse.go
+++ b/pkg/clickhouse/clickhouse.go
@@ -43,9 +43,10 @@ func (ch *ClickHouse) Connect() error {
 	params.Add("username", ch.Config.Username)
 	params.Add("password", ch.Config.Password)
 	params.Add("database", "system")
-	params.Add("read_timeout", timeoutSeconds)
+	params.Add("connect_timeout", timeoutSeconds)
 	params.Add("receive_timeout", timeoutSeconds)
 	params.Add("send_timeout", timeoutSeconds)
+	params.Add("timeout", timeoutSeconds)
 	params.Add("read_timeout", timeoutSeconds)
 	params.Add("write_timeout", timeoutSeconds)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1076,11 +1076,19 @@ func (api *APIServer) CreateIntegrationTables() error {
 	if api.config.API.Secure {
 		schema = "https"
 	}
-	query := fmt.Sprintf("CREATE TABLE system.backup_actions (command String, start DateTime, finish DateTime, status String, error String) ENGINE=URL('%s://127.0.0.1:%s/backup/actions%s', JSONEachRow) SETTINGS input_format_skip_unknown_fields=1", schema, port, auth)
+	settings := ""
+	version, err := ch.GetVersion()
+	if err != nil {
+		return err
+	}
+	if version >= 21001000 {
+		settings = "SETTINGS input_format_skip_unknown_fields=1"
+	}
+	query := fmt.Sprintf("CREATE TABLE system.backup_actions (command String, start DateTime, finish DateTime, status String, error String) ENGINE=URL('%s://127.0.0.1:%s/backup/actions%s', JSONEachRow) %s", schema, port, auth, settings)
 	if err := ch.CreateTable(clickhouse.Table{Database: "system", Name: "backup_actions"}, query, true); err != nil {
 		return err
 	}
-	query = fmt.Sprintf("CREATE TABLE system.backup_list (name String, created DateTime, size Int64, location String, required String, desc String) ENGINE=URL('%s://127.0.0.1:%s/backup/list%s', JSONEachRow) SETTINGS input_format_skip_unknown_fields=1", schema, port, auth)
+	query = fmt.Sprintf("CREATE TABLE system.backup_list (name String, created DateTime, size Int64, location String, required String, desc String) ENGINE=URL('%s://127.0.0.1:%s/backup/list%s', JSONEachRow) %s", schema, port, auth, settings)
 	if err := ch.CreateTable(clickhouse.Table{Database: "system", Name: "backup_list"}, query, true); err != nil {
 		return err
 	}

--- a/test/integration/config-s3.yml
+++ b/test/integration/config-s3.yml
@@ -3,6 +3,8 @@ general:
   remote_storage: s3
   upload_concurrency: 4
   download_concurrency: 4
+  skip_tables:
+   - " system.*"
 clickhouse:
   host: 127.0.0.1
   port: 9440

--- a/test/integration/config-s3.yml
+++ b/test/integration/config-s3.yml
@@ -24,3 +24,4 @@ s3:
   disable_ssl: true
 api:
   listen: :7171
+  create_integration_tables: true

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -740,13 +740,15 @@ func TestTablePatterns(t *testing.T) {
 
 	var restoredTables []uint64
 	r.NoError(ch.chbackup.Select(&restoredTables, fmt.Sprintf("SELECT count() FROM system.tables WHERE database='%s'", dbNameOrdinary)))
-	r.True(len(restoredTables) > 0)
+	r.NotZero(len(restoredTables))
 	r.NotZero(restoredTables[0])
 
 	restoredTables = make([]uint64, 0)
 	r.NoError(ch.chbackup.Select(&restoredTables, fmt.Sprintf("SELECT count() FROM system.tables WHERE database='%s'", dbNameAtomic)))
-	r.True(len(restoredTables) > 0)
-	r.Zero(restoredTables[0])
+	// old versions of clickhouse will return empty recordset
+	if len(restoredTables) > 0 {
+		r.Zero(restoredTables[0])
+	}
 }
 
 func testCommon(t *testing.T) {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -492,6 +492,9 @@ func TestServerAPI(t *testing.T) {
 	r.NotContains(out, "another operation is currently running")
 	r.NotContains(out, "\"status\":\"error\"")
 
+	log.Info("Check /backup/actions")
+	ch.queryWithNoError(r, "SELECT count() FROM system.backup_actions")
+
 	log.Info("Check /backup/upload")
 	out, err = dockerExecOut(
 		"clickhouse",

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -88,16 +88,16 @@ var testData = []TestDataStruct{
 	}, {
 		Database: dbNameAtomic, DatabaseEngine: "Atomic",
 		Table:  "table4",
-		Schema: "(id UInt64, Col1 String, Col2 String, Col3 String, Col4 String, Col5 String) ENGINE = MergeTree PARTITION BY id ORDER BY (id, Col1, Col2, Col3, Col4, Col5) SETTINGS index_granularity = 8192",
+		Schema: "(table4 UInt64, Col1 String, Col2 String, Col3 String, Col4 String, Col5 String) ENGINE = MergeTree PARTITION BY table4 ORDER BY (table4, Col1, Col2, Col3, Col4, Col5) SETTINGS index_granularity = 8192",
 		Rows: func() []map[string]interface{} {
 			var result []map[string]interface{}
 			for i := 0; i < 100; i++ {
-				result = append(result, map[string]interface{}{"id": uint64(i), "Col1": "Text1", "Col2": "Text2", "Col3": "Text3", "Col4": "Text4", "Col5": "Text5"})
+				result = append(result, map[string]interface{}{"table4": uint64(i), "Col1": "Text1", "Col2": "Text2", "Col3": "Text3", "Col4": "Text4", "Col5": "Text5"})
 			}
 			return result
 		}(),
-		Fields:  []string{"id", "Col1", "Col2", "Col3", "Col4", "Col5"},
-		OrderBy: "id",
+		Fields:  []string{"table4", "Col1", "Col2", "Col3", "Col4", "Col5"},
+		OrderBy: "table4",
 	}, {
 		Database: dbNameOrdinary, DatabaseEngine: "Ordinary",
 		Table:  "yuzhichang_table2",
@@ -236,7 +236,7 @@ var testData = []TestDataStruct{
 		IsDictionary:   true,
 		Table:          "dict_example",
 		Schema: fmt.Sprintf(
-			" (id UInt64, Col1 String, Col2 String, Col3 String, Col4 String, Col5 String) PRIMARY KEY id "+
+			" (table4 UInt64, Col1 String, Col2 String, Col3 String, Col4 String, Col5 String) PRIMARY KEY table4 "+
 				" SOURCE(CLICKHOUSE(host 'localhost' port 9000 database '%s' table 'table4' user 'default' password ''))"+
 				" LAYOUT(HASHED()) LIFETIME(60)",
 			dbNameAtomic),
@@ -244,12 +244,12 @@ var testData = []TestDataStruct{
 		Rows: func() []map[string]interface{} {
 			var result []map[string]interface{}
 			for i := 0; i < 100; i++ {
-				result = append(result, map[string]interface{}{"id": uint64(i), "Col1": "Text1", "Col2": "Text2", "Col3": "Text3", "Col4": "Text4", "Col5": "Text5"})
+				result = append(result, map[string]interface{}{"table4": uint64(i), "Col1": "Text1", "Col2": "Text2", "Col3": "Text3", "Col4": "Text4", "Col5": "Text5"})
 			}
 			return result
 		}(),
 		Fields:  []string{"id"},
-		OrderBy: "id",
+		OrderBy: "table4",
 	},
 	{
 		Database: dbNameMySQL, DatabaseEngine: "MySQL('mysql:3306','mysql','root','root')",
@@ -292,16 +292,16 @@ var incrementData = []TestDataStruct{
 	}, {
 		Database: dbNameAtomic, DatabaseEngine: "Atomic",
 		Table:  "table4",
-		Schema: "(id UInt64, Col1 String, Col2 String, Col3 String, Col4 String, Col5 String) ENGINE = MergeTree PARTITION BY id ORDER BY (id, Col1, Col2, Col3, Col4, Col5) SETTINGS index_granularity = 8192",
+		Schema: "(table4 UInt64, Col1 String, Col2 String, Col3 String, Col4 String, Col5 String) ENGINE = MergeTree PARTITION BY table4 ORDER BY (table4, Col1, Col2, Col3, Col4, Col5) SETTINGS index_granularity = 8192",
 		Rows: func() []map[string]interface{} {
 			var result []map[string]interface{}
 			for i := 200; i < 220; i++ {
-				result = append(result, map[string]interface{}{"id": uint64(i), "Col1": "Text1", "Col2": "Text2", "Col3": "Text3", "Col4": "Text4", "Col5": "Text5"})
+				result = append(result, map[string]interface{}{"table4": uint64(i), "Col1": "Text1", "Col2": "Text2", "Col3": "Text3", "Col4": "Text4", "Col5": "Text5"})
 			}
 			return result
 		}(),
-		Fields:  []string{"id", "Col1", "Col2", "Col3", "Col4", "Col5"},
-		OrderBy: "id",
+		Fields:  []string{"table4", "Col1", "Col2", "Col3", "Col4", "Col5"},
+		OrderBy: "table4",
 	}, {
 		Database: dbNameOrdinary, DatabaseEngine: "Ordinary",
 		Table:  "yuzhichang_table2",

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -494,6 +494,24 @@ func TestServerAPI(t *testing.T) {
 	r.NotContains(out, "another operation is currently running")
 	r.NotContains(out, "\"status\":\"error\"")
 
+	log.Info("Check /backup/tables")
+	out, err = dockerExecOut(
+		"clickhouse",
+		"bash", "-xe", "-c", "curl -sL \"http://localhost:7171/backup/tables\"",
+	)
+	log.Debug(out)
+	r.NoError(err)
+	r.NotContains(out, "system")
+
+	log.Info("Check /backup/tables/all")
+	out, err = dockerExecOut(
+		"clickhouse",
+		"bash", "-xe", "-c", "curl -sL \"http://localhost:7171/backup/tables/all\"",
+	)
+	log.Debug(out)
+	r.NoError(err)
+	r.Contains(out, "system")
+
 	log.Info("Check /backup/actions")
 	ch.queryWithNoError(r, "SELECT count() FROM system.backup_actions")
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -733,18 +733,18 @@ func TestTablePatterns(t *testing.T) {
 	generateTestData(ch, r)
 	r.NoError(dockerCP("config-s3.yml", "clickhouse:/etc/clickhouse-backup/config.yml"))
 
-	r.NoError(dockerExec("clickhouse", "clickhouse-backup", "create_remote", "--tables", " "+dbNameAtomic+".*", testBackupName))
+	r.NoError(dockerExec("clickhouse", "clickhouse-backup", "create_remote", "--tables", " "+dbNameOrdinary+".*", testBackupName))
 	r.NoError(dockerExec("clickhouse", "clickhouse-backup", "delete", "local", testBackupName))
 	dropAllDatabases(r, ch)
-	r.NoError(dockerExec("clickhouse", "clickhouse-backup", "restore_remote", "--tables", " "+dbNameAtomic+".*", testBackupName))
+	r.NoError(dockerExec("clickhouse", "clickhouse-backup", "restore_remote", "--tables", " "+dbNameOrdinary+".*", testBackupName))
 
 	var restoredTables []uint64
-	r.NoError(ch.chbackup.Select(&restoredTables, fmt.Sprintf("SELECT count() FROM system.tables WHERE database='%s'", dbNameAtomic)))
+	r.NoError(ch.chbackup.Select(&restoredTables, fmt.Sprintf("SELECT count() FROM system.tables WHERE database='%s'", dbNameOrdinary)))
 	r.True(len(restoredTables) > 0)
 	r.NotZero(restoredTables[0])
 
 	restoredTables = make([]uint64, 0)
-	r.NoError(ch.chbackup.Select(&restoredTables, fmt.Sprintf("SELECT count() FROM system.tables WHERE database='%s'", dbNameOrdinary)))
+	r.NoError(ch.chbackup.Select(&restoredTables, fmt.Sprintf("SELECT count() FROM system.tables WHERE database='%s'", dbNameAtomic)))
 	r.True(len(restoredTables) > 0)
 	r.Zero(restoredTables[0])
 }


### PR DESCRIPTION
IMPROVEMENTS
- Add REST API `POST /backup/tables/all`, fix `POST /backup/tables` to respect `CLICKHOUSE_SKIP_TABLES`

BUG FIXES
- fix https://github.com/AlexAkulov/clickhouse-backup/issues/297, properly restore tables where have fields with the same name as table name
- fix https://github.com/AlexAkulov/clickhouse-backup/issues/298, properly create `system.backup_actions` and `system.backup_list` integration tables for ClickHouse before 21.1
- fix https://github.com/AlexAkulov/clickhouse-backup/issues/303, ignore leading and trailing spaces in `skip_tables` and `--tables` parameters
- fix https://github.com/AlexAkulov/clickhouse-backup/issues/292, lock clickhouse connection pool to single connection