### PR TITLE
Set default value for max_parts_count in Azure config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"crypto/tls"
 	"fmt"
-	"github.com/urfave/cli"
 	"io/ioutil"
 	"math"
 	"os"
@@ -14,6 +13,7 @@ import (
 	"github.com/apex/log"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/kelseyhightower/envconfig"
+	"github.com/urfave/cli"
 	"gopkg.in/yaml.v2"
 )
 
@@ -358,6 +358,7 @@ func DefaultConfig() *Config {
 			CompressionFormat: "tar",
 			BufferSize:        0,
 			MaxBuffers:        3,
+			MaxPartsCount:     10000,
 		},
 		S3: S3Config{
 			Region:                  "us-east-1",


### PR DESCRIPTION
Hi and thanks for the awesome project.

We updated the `clickhouse-backup` container today from version 1.3.1 to 1.4.0. After the update the container didn't come up with the following error message:

```
2022/06/03 11:41:34.529040  info Starting API server on 0.0.0.0:7171
2022/06/03 11:41:34.529939  info Update backup metrics start (onlyLocal=false)
2022/06/03 11:41:34.533061  info SELECT value FROM `system`.`build_options` where name='VERSION_INTEGER'
2022/06/03 11:41:34.536590  info SELECT * FROM system.disks;
2022/06/03 11:41:34.542677  info SELECT count() AS is_macros_exists FROM system.tables WHERE database='system' AND table='macros'
2022/06/03 11:41:34.546212  info SELECT * FROM system.macros
2022/06/03 11:41:34.623663  info Update backup metrics finish LastBackupSizeLocal=10451025869 LastBackupSizeRemote=0 NumberBackupsLocal=1 NumberBackupsRemote=0 duration=94ms
panic: runtime error: integer divide by zero

goroutine 60 [running]:
github.com/AlexAkulov/clickhouse-backup/pkg/new_storage.NewBackupDestination(0xc0001ab080, 0x0?)
    /home/runner/work/clickhouse-backup/clickhouse-backup/pkg/new_storage/general.go:578 +0x9ad
github.com/AlexAkulov/clickhouse-backup/pkg/backup.GetRemoteBackups(0x3?, 0x0)
    /home/runner/work/clickhouse-backup/clickhouse-backup/pkg/backup/print.go:237 +0x7e
github.com/AlexAkulov/clickhouse-backup/pkg/server.(*APIServer).updateBackupMetrics(0xc0004b81e0, 0x0)
    /home/runner/work/clickhouse-backup/clickhouse-backup/pkg/server/server.go:1028 +0x345
github.com/AlexAkulov/clickhouse-backup/pkg/server.Server.func1()
    /home/runner/work/clickhouse-backup/clickhouse-backup/pkg/server/server.go:194 +0x25
created by github.com/AlexAkulov/clickhouse-backup/pkg/server.Server
    /home/runner/work/clickhouse-backup/clickhouse-backup/pkg/server/server.go:193 +0x52f
Stream closed EOF for analytics/chi-clickhouse-replicated-0-0-0 (clickhouse-backup)
```

After setting the `AZBLOB_MAX_PARTS_COUNT` environment variable to `10000`, the container was working as expected, so I think it would be a good idea to set a default value for it as it is done for S3.