### PR TITLE
base64 encoded credentials string for remote_storage: gcp

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -173,6 +173,7 @@ s3:
 gcs:
   credentials_file: ""         # GCS_CREDENTIALS_FILE
   credentials_json: ""         # GCS_CREDENTIALS_JSON
+  credentials_json_encoded: "" # GCS_CREDENTIALS_JSON_ENCODED
   bucket: ""                   # GCS_BUCKET
   path: ""                     # GCS_PATH
   compression_level: 1         # GCS_COMPRESSION_LEVEL

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,15 +51,16 @@ type GeneralConfig struct {
 
 // GCSConfig - GCS settings section
 type GCSConfig struct {
-	CredentialsFile   string `yaml:"credentials_file" envconfig:"GCS_CREDENTIALS_FILE"`
-	CredentialsJSON   string `yaml:"credentials_json" envconfig:"GCS_CREDENTIALS_JSON"`
-	Bucket            string `yaml:"bucket" envconfig:"GCS_BUCKET"`
-	Path              string `yaml:"path" envconfig:"GCS_PATH"`
-	CompressionLevel  int    `yaml:"compression_level" envconfig:"GCS_COMPRESSION_LEVEL"`
-	CompressionFormat string `yaml:"compression_format" envconfig:"GCS_COMPRESSION_FORMAT"`
-	Debug             bool   `yaml:"debug" envconfig:"GCS_DEBUG"`
-	Endpoint          string `yaml:"endpoint" envconfig:"GCS_ENDPOINT"`
-	StorageClass      string `yaml:"storage_class" envconfig:"GCS_STORAGE_CLASS"`
+	CredentialsFile        string `yaml:"credentials_file" envconfig:"GCS_CREDENTIALS_FILE"`
+	CredentialsJSON        string `yaml:"credentials_json" envconfig:"GCS_CREDENTIALS_JSON"`
+	CredentialsJSONEncoded string `yaml:"credentials_json_encoded" envconfig:"GCS_CREDENTIALS_JSON_ENCODED"`
+	Bucket                 string `yaml:"bucket" envconfig:"GCS_BUCKET"`
+	Path                   string `yaml:"path" envconfig:"GCS_PATH"`
+	CompressionLevel       int    `yaml:"compression_level" envconfig:"GCS_COMPRESSION_LEVEL"`
+	CompressionFormat      string `yaml:"compression_format" envconfig:"GCS_COMPRESSION_FORMAT"`
+	Debug                  bool   `yaml:"debug" envconfig:"GCS_DEBUG"`
+	Endpoint               string `yaml:"endpoint" envconfig:"GCS_ENDPOINT"`
+	StorageClass           string `yaml:"storage_class" envconfig:"GCS_STORAGE_CLASS"`
 }
 
 // AzureBlobConfig - Azure Blob settings section

--- a/pkg/storage/gcs.go
+++ b/pkg/storage/gcs.go
@@ -2,14 +2,16 @@ package storage
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
-	"github.com/AlexAkulov/clickhouse-backup/pkg/config"
-	"google.golang.org/api/option/internaloption"
 	"io"
 	"net/http"
 	"path"
 	"strings"
 	"time"
+
+	"github.com/AlexAkulov/clickhouse-backup/pkg/config"
+	"google.golang.org/api/option/internaloption"
 
 	"cloud.google.com/go/storage"
 	"github.com/apex/log"
@@ -65,6 +67,9 @@ func (gcs *GCS) Connect() error {
 		clientOptions = append(clientOptions, option.WithEndpoint(endpoint))
 	} else if gcs.Config.CredentialsJSON != "" {
 		clientOptions = append(clientOptions, option.WithCredentialsJSON([]byte(gcs.Config.CredentialsJSON)))
+	} else if gcs.Config.CredentialsJSONEncoded != "" {
+		d, _ := base64.StdEncoding.DecodeString(gcs.Config.CredentialsJSON)
+		clientOptions = append(clientOptions, option.WithCredentialsJSON([]byte(d)))
 	} else if gcs.Config.CredentialsFile != "" {
 		clientOptions = append(clientOptions, option.WithCredentialsFile(gcs.Config.CredentialsFile))
 	}

--- a/test/testflows/README.md
+++ b/test/testflows/README.md
@@ -32,6 +32,7 @@ Some environment variables required to be set up before test execution:
   - `QA_AWS_REGION`
   - `QA_AWS_BUCKET`
   - `QA_GCS_CRED_JSON`
+  - `QA_GCS_CRED_JSON_ENCODED`
 
 You can do it with something like that:
 
@@ -44,6 +45,7 @@ export QA_AWS_SECRET_KEY=XXXXXX
 export QA_AWS_REGION=XXXXXX
 export QA_AWS_BUCKET=XXXXXX
 export QA_GCS_CRED_JSON=XXXXXX
+export QA_GCS_CRED_JSON_ENCODED=XXXXXX
 EOT
 source /home/username/clickhouse-backup/test/testflows/.env
 ```

--- a/test/testflows/clickhouse_backup/configs/backup/config.yml
+++ b/test/testflows/clickhouse_backup/configs/backup/config.yml
@@ -62,6 +62,7 @@ gcs:
   compression_level: 3
   credentials_file: ''
   credentials_json: ''
+  credentials_json_encoded: ''
   debug: false
 general:
   allow_empty_backups: false

--- a/test/testflows/clickhouse_backup/docker-compose/docker-compose.yml
+++ b/test/testflows/clickhouse_backup/docker-compose/docker-compose.yml
@@ -112,6 +112,7 @@ services:
     environment:
       - DEBIAN_FRONTEND=noninteractive
       - GCS_CREDENTIALS_JSON=${QA_GCS_CRED_JSON}
+      - GCS_CREDENTIALS_JSON_ENCODED=${QA_GCS_CRED_JSON_ENCODED}
       - CLICKHOUSE_HOST=clickhouse1
       - CLICKHOUSE_BACKUP_CONFIG=/etc/clickhouse-backup/config.yml
       - TZ=Europe/Moscow

--- a/test/testflows/clickhouse_backup/requirements/requirements.md
+++ b/test/testflows/clickhouse_backup/requirements/requirements.md
@@ -704,6 +704,7 @@ s3:
 gcs:
   credentials_file: ""         # GCS_CREDENTIALS_FILE
   credentials_json: ""         # GCS_CREDENTIALS_JSON
+  credentials_json_encoded: "" # GCS_CREDENTIALS_JSON_ENCODED
   bucket: ""                   # GCS_BUCKET
   path: ""                     # GCS_PATH
   compression_level: 1         # GCS_COMPRESSION_LEVEL

--- a/test/testflows/clickhouse_backup/requirements/requirements.py
+++ b/test/testflows/clickhouse_backup/requirements/requirements.py
@@ -1102,6 +1102,7 @@ RQ_SRS_013_ClickHouse_BackupUtility_Configuration = Requirement(
         'gcs:\n'
         '  credentials_file: ""         # GCS_CREDENTIALS_FILE\n'
         '  credentials_json: ""         # GCS_CREDENTIALS_JSON\n'
+        '  credentials_json_encoded: "" # GCS_CREDENTIALS_JSON_ENCODED\n'
         '  bucket: ""                   # GCS_BUCKET\n'
         '  path: ""                     # GCS_PATH\n'
         '  compression_level: 1         # GCS_COMPRESSION_LEVEL\n'
@@ -2485,6 +2486,7 @@ s3:
 gcs:
   credentials_file: ""         # GCS_CREDENTIALS_FILE
   credentials_json: ""         # GCS_CREDENTIALS_JSON
+  credentials_json_encoded: "" # GCS_CREDENTIALS_JSON_ENCODED'
   bucket: ""                   # GCS_BUCKET
   path: ""                     # GCS_PATH
   compression_level: 1         # GCS_COMPRESSION_LEVEL

--- a/test/testflows/clickhouse_backup/tests/cloud_storage.py
+++ b/test/testflows/clickhouse_backup/tests/cloud_storage.py
@@ -194,8 +194,8 @@ def s3_aws(self):
 def gcs(self):
     """Test that an existing backup can be uploaded to GCS bucket.
     """
-    if not os.environ.get('QA_GCS_CRED_JSON'):
-        skip("QA_GCS_CRED_JSON environment not found, test skipped")
+    if not (os.environ.get('QA_GCS_CRED_JSON') or os.environ.get('QA_GCS_CRED_JSON_ENCODED')):
+        skip("QA_GCS_CRED_JSON/QA_GCS_CRED_JSON_ENCODED environment not found, test skipped")
 
     test_storage_outline(storage_type="gcs")
 


### PR DESCRIPTION
this should allow to pass encoded string to "WithCredentialsJSON".

fix https://github.com/AlexAkulov/clickhouse-backup/issues/498