### PR TITLE
release 2.1.2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# TODO
+IMPROVEMENTS
+- add `watch` description to Examples.md
+
 # v2.1.1
 BUG FIXES
 - return bash and clickhouse usergroup to Dockerfile image short, fix [542](https://github.com/AlexAkulov/clickhouse-backup/issues/542)
@@ -26,7 +30,7 @@ BUG FIXES
 # v2.0.0
 IMPROVEMENTS
 - implements `remote_storage: custom`, which allow us to adopt any external backup system like `restic`, `kopia`, `rsync`, rclone etc. fix [383](https://github.com/AlexAkulov/clickhouse-backup/issues/383)
-- add example workflow hot to make backup / restore on sharded cluster, fix [469](https://github.com/AlexAkulov/clickhouse-backup/discussions/469)
+- add example workflow how to make backup / restore on sharded cluster, fix [469](https://github.com/AlexAkulov/clickhouse-backup/discussions/469)
 - add `use_embedded_backup_restore` to allow `BACKUP` and `RESTORE` SQL commands usage, fix [323](https://github.com/AlexAkulov/clickhouse-backup/issues/323), need 22.7+ and resolve https://github.com/ClickHouse/ClickHouse/issues/39416
 - add `timeout` to `azure` config `AZBLOB_TIMEOUT` to allow download with bad network quality, fix [467](https://github.com/AlexAkulov/clickhouse-backup/issues/467)
 - switch to go 1.19

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,10 @@
-# TODO
+# v2.1.2
 IMPROVEMENTS
 - add `watch` description to Examples.md
+
+BUG FIXES
+- fix panic when use `--restore-database-mapping=db1:db2`, fix [545](https://github.com/AlexAkulov/clickhouse-backup/issues/545)
+- fix panic when use `--partitions=XXX`, fix [544](https://github.com/AlexAkulov/clickhouse-backup/issues/545)
 
 # v2.1.1
 BUG FIXES

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# v2.1.1
+BUG FIXES
+- return bash and clickhouse usergroup to Dockerfile image short, fix [542](https://github.com/AlexAkulov/clickhouse-backup/issues/542)
+
 # v2.1.0
 IMPROVEMENTS
 - complex refactoring to use contexts, AWS and SFTP storage not full supported

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,11 @@ FROM alpine:3.16 AS image_short
 ARG TARGETPLATFORM
 MAINTAINER Eugene Klimov <eklimov@altinity.com>
 
+RUN addgroup -S -g 101 clickhouse \
+    && adduser -S -h /var/lib/clickhouse -s /bin/bash -G clickhouse -g "ClickHouse server" -u 101 clickhouse
+
+RUN apk update && apk add --no-cache ca-certificates tzdata bash curl && update-ca-certificates
+
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 COPY build/${TARGETPLATFORM}/clickhouse-backup /bin/clickhouse-backup

--- a/Examples.md
+++ b/Examples.md
@@ -385,3 +385,8 @@ spec:
 - During download, if backup contains link to `required` backup it will try to fully download first. This action apply recursively. If you have a chain of incremental backups, all incremental backups in the chain and first "full" will download to local storage. 
 - Size of increment depends not only on the intensity your data ingestion and also depends on the intensity background merges for data parts in your tables. Please increase how much rows you will ingest during one INSERT query and don't apply often [table data mutations](https://clickhouse.tech/docs/en/operations/system-tables/mutations/).
 - Look to [ClicHouse documentation](https://clickhouse.tech/docs/en/engines/table-engines/mergetree-family/mergetree/) and try to understand how exactly `*MergeTree` table engine works.
+
+## How to work `watch` command
+Current implementation simple and will improve in next releases
+- When `watch` command start, it call create_remote+delete command sequence to make `full` backup
+- Then it wait `watch-interval` time period and call create_remote+delete command sequence again, type of backup will `full` if `full-interval` expired after last full backup created and `incremental`, if not.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -311,7 +311,7 @@ You can't run watch twice with the same parameters even when `allow_parallel: tr
 * Optional query argument `configs` works the same the `--configs` CLI argument (backup configs).
 * Additional example: `curl -s 'localhost:7171/backup/watch?table=default.billing&watch_interval=1h&full_interval=24h' -X POST`
 
-Note: this operation is async, so the API will return once the operation has been started.
+Note: this operation is async and can stop only with `kill -s SIGHUP $(pgrep -f clickhouse-backup)` or call `/restart`, `/backup/kill`, so the API will return once the operation has been started.
 
 > **POST /backup/clean**
 
@@ -445,3 +445,4 @@ fi
 - [How to make back up database with several terabytes of data](Examples.md#how-to-make-backup-database-with-several-terabytes-of-data)
 - [How to use clickhouse-backup in Kubernetes](Examples.md#how-to-use-clickhouse-backup-in-kubernetes)
 - [How do incremental backups work to remote storage](Examples.md#how-do-incremental-backups-work-to-remote-storage)
+- [How to watch backups work](Examples.md#how-to-work-watch-command)

--- a/pkg/backup/table_pattern.go
+++ b/pkg/backup/table_pattern.go
@@ -186,12 +186,13 @@ func changeTableQueryToAdjustDatabaseMapping(originTables *ListOfTables, dbMapRu
 func filterPartsByPartitionsFilter(tableMetadata metadata.TableMetadata, partitionsFilter common.EmptyMap) {
 	if len(partitionsFilter) > 0 {
 		for disk, parts := range tableMetadata.Parts {
-			for i, part := range parts {
-				if !filesystemhelper.IsPartInPartition(part.Name, partitionsFilter) {
-					parts = append(parts[:i], parts[i+1:]...)
+			filteredParts := make([]metadata.Part, 0)
+			for _, part := range parts {
+				if filesystemhelper.IsPartInPartition(part.Name, partitionsFilter) {
+					filteredParts = append(filteredParts, part)
 				}
 			}
-			tableMetadata.Parts[disk] = parts
+			tableMetadata.Parts[disk] = filteredParts
 		}
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -420,6 +420,7 @@ func DefaultConfig() *Config {
 			FullInterval:            "24h",
 			FullDuration:            24 * time.Hour,
 			WatchBackupNameTemplate: "shard{shard}-{type}-{time:20060102150405}",
+			RestoreDatabaseMapping:  make(map[string]string, 0),
 		},
 		ClickHouse: ClickHouseConfig{
 			Username: "default",

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1838,9 +1838,10 @@ func testBackupSpecifiedPartitions(r *require.Assertions, ch *TestClickHouse) {
 	ch.queryWithNoError(r, "INSERT INTO default.t1 SELECT '2022-01-01 00:00:00', number FROM numbers(10)")
 	ch.queryWithNoError(r, "INSERT INTO default.t1 SELECT '2022-01-02 00:00:00', number FROM numbers(10)")
 	ch.queryWithNoError(r, "INSERT INTO default.t1 SELECT '2022-01-03 00:00:00', number FROM numbers(10)")
+	ch.queryWithNoError(r, "INSERT INTO default.t1 SELECT '2022-01-04 00:00:00', number FROM numbers(10)")
 	// Backup
 
-	r.NoError(dockerExec("clickhouse", "clickhouse-backup", "create_remote", "--tables=default.t1", "--partitions=20220101,20220102", partitionBackupName))
+	r.NoError(dockerExec("clickhouse", "clickhouse-backup", "create_remote", "--tables=default.t1", "--partitions=20220102,20220103", partitionBackupName))
 
 	// TRUNCATE TABLE
 	ch.queryWithNoError(r, "TRUNCATE table default.t1")
@@ -1852,7 +1853,7 @@ func testBackupSpecifiedPartitions(r *require.Assertions, ch *TestClickHouse) {
 	// Check
 	var result []int
 
-	r.NoError(ch.chbackend.Select(&result, "SELECT count() FROM default.t1 WHERE dt IN ('2022-01-01 00:00:00','2022-01-02 00:00:00')"))
+	r.NoError(ch.chbackend.Select(&result, "SELECT count() FROM default.t1 WHERE dt IN ('2022-01-02 00:00:00','2022-01-03 00:00:00')"))
 
 	// Must have one value
 	log.Debugf("testBackupSpecifiedPartitions result : '%v'", result)
@@ -1863,7 +1864,7 @@ func testBackupSpecifiedPartitions(r *require.Assertions, ch *TestClickHouse) {
 
 	// Reset the result.
 	result = make([]int, 0)
-	r.NoError(ch.chbackend.Select(&result, "SELECT count() FROM default.t1 WHERE dt NOT IN ('2022-01-01 00:00:00','2022-01-02 00:00:00')"))
+	r.NoError(ch.chbackend.Select(&result, "SELECT count() FROM default.t1 WHERE dt NOT IN ('2022-01-02 00:00:00','2022-01-03 00:00:00')"))
 
 	log.Debugf("testBackupSpecifiedPartitions result : '%v'", result)
 	log.Debugf("testBackupSpecifiedPartitions result' length '%d'", len(result))


### PR DESCRIPTION
# v2.1.2
IMPROVEMENTS
- add `watch` description to Examples.md

BUG FIXES
- fix panic when use `--restore-database-mapping=db1:db2`, fix https://github.com/AlexAkulov/clickhouse-backup/issues/545
- fix panic when use `--partitions=XXX`, fix https://github.com/AlexAkulov/clickhouse-backup/issues/545
