### PR TITLE
fixed bug for watch as a arg in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]] || [[ ! -x  $(command -v "$1") ]]; then
+if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]] || [[ ! -x  $(command -v "$1") ]] || [[ "$1" == "watch" ]]; then
     exec /bin/clickhouse-backup "$@"
 fi
 exec "$@"


### PR DESCRIPTION
in the entrypoint.sh there is a condition which says if the command is executable it will not run the clickhouse-backup command and will directly execute it :

i was providing this as args while running the container to use watch feature of clickhouse-backup:
watch --watch-interval 23h --full-interval 24h --watch-backup-name-template=shard{shard}-{type}-{time:20060102150405}

but it was runing watch command of linux as there is condition check in entrypoint.sh [[ ! -x  $(command -v "$1") ]]  which means if the arg that is provided is executable dont append it with /bin/clickhouse , instead directly execute the executable command 

i added one more check in the entrypoint.sh that if we provide watch in arg while runnning the container it should append it to clickhouse-backup command and not directly execute it as command . 