### PR TITLE
server: Add callbacks query param

### DIFF
--- a/pkg/server/callback.go
+++ b/pkg/server/callback.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// callbackFn is a function which will post a callback when invoked
+type callbackFn func(ctx context.Context, v interface{}) []error
+
+// parseCallback parses a callback URL from URL query values and returns a closure which can send
+// a payload back to the specified URL when invoked.
+func parseCallback(query url.Values) (callbackFn, error) {
+	encodedURLs, exist := query["callback"]
+	if !exist {
+		noOpCallback := func(_ context.Context, _ interface{}) []error {
+			return nil
+		}
+		return noOpCallback, nil
+	}
+
+	decodedURLs := make([]string, len(encodedURLs))
+	for i, v := range encodedURLs {
+		d, err := url.QueryUnescape(v)
+		if err != nil {
+			return nil, fmt.Errorf("could not decode url %q: %w", v, err)
+		}
+		decodedURLs[i] = d
+	}
+
+	client := &http.Client{}
+	return func(ctx context.Context, v interface{}) []error {
+		payload, err := json.Marshal(v)
+		if err != nil {
+			return []error{fmt.Errorf("error encoding %v: %w", v, err)}
+		}
+
+		var errors []error
+		for _, url := range decodedURLs {
+			reader := bytes.NewReader(payload)
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, reader)
+			if err != nil {
+				errors = append(errors, fmt.Errorf("error creating request to %q: %w", url, err))
+				continue
+			}
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := client.Do(req)
+			if err != nil {
+				errors = append(errors, fmt.Errorf("error while posting callback to %q: %w", url,
+					err))
+				continue
+			}
+			if resp.StatusCode != http.StatusOK {
+				errors = append(errors, fmt.Errorf("error while posting callback to %q: "+
+					"status code %d", url, resp.StatusCode))
+			}
+		}
+		return errors
+	}, nil
+}

--- a/pkg/server/callback_test.go
+++ b/pkg/server/callback_test.go
@@ -1,0 +1,166 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/gorilla/mux"
+)
+
+func TestParseCallback(t *testing.T) {
+	ctx := context.Background()
+
+	// Test server setup
+	type payload struct {
+		Key string `json:"key"`
+		Val string `json:"val"`
+	}
+
+	goodEndpoint1 := "/good1"
+	goodEndpoint2 := "/good2"
+	badEndpoint := "/bad"
+	goodChan1 := make(chan *payload, 5)
+	goodChan2 := make(chan *payload, 5)
+
+	passToChanHandler := func(ch chan *payload) http.HandlerFunc {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer r.Body.Close()
+
+			var data payload
+			if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+			ch <- &data
+			if _, err := w.Write(nil); err != nil {
+				t.Fatalf("unexpected error while writing response from test server: %v", err)
+			}
+		})
+	}
+	returnErrHandler := http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "bad endpoint error", http.StatusInternalServerError)
+		})
+
+	router := mux.NewRouter()
+	router.Handle(goodEndpoint1, passToChanHandler(goodChan1))
+	router.Handle(goodEndpoint2, passToChanHandler(goodChan2))
+	router.Handle(badEndpoint, returnErrHandler)
+
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	t.Log("Test empty callback")
+	values := url.Values{}
+	cb, err := parseCallback(values)
+	if err != nil {
+		t.Fatalf("unexpected error when getting callback for empty values: %v", err)
+	}
+	if err := cb(ctx, nil); err != nil {
+		t.Fatalf("unexpected error when calling callback for empty values: %v", err)
+	}
+
+	t.Log("Test invalid callback URL")
+	values = url.Values{
+		"callback": []string{
+			"valid",
+			"invalid%",
+		},
+	}
+	_, err = parseCallback(values)
+	if err == nil {
+		t.Fatalf("expected error when passing invalid callback URL")
+	}
+
+	t.Log("Test normal callbacks")
+	values = url.Values{
+		"callback": []string{
+			url.QueryEscape(srv.URL + goodEndpoint1),
+			url.QueryEscape(srv.URL + goodEndpoint2),
+		},
+	}
+	cb, err = parseCallback(values)
+	if err != nil {
+		t.Fatalf("unexpected error when getting callback for good endpoints: %v", err)
+	}
+	pl := payload{Key: "a", Val: "b"}
+	if err := cb(ctx, pl); err != nil {
+		t.Fatalf("unexpected error when calling callbacks for good endpoints: %v", err)
+	}
+
+	if val1 := <-goodChan1; !reflect.DeepEqual(val1, &pl) {
+		t.Fatalf("expected %v, got %v", pl, val1)
+	}
+	if val2 := <-goodChan2; !reflect.DeepEqual(val2, &pl) {
+		t.Fatalf("expected %v, got %v", pl, val2)
+	}
+
+	t.Log("Test bad callback - unresponsive host")
+	values = url.Values{
+		"callback": []string{
+			url.QueryEscape(srv.URL + goodEndpoint1),
+			url.QueryEscape("invalid.url.local"),
+		},
+	}
+	cb, err = parseCallback(values)
+	if err != nil {
+		t.Fatalf("unexpected error when getting callback for bad host: %v", err)
+	}
+	pl = payload{Key: "c", Val: "d"}
+	if err := cb(ctx, pl); err == nil {
+		t.Fatalf("expected error when calling bad host callback")
+	}
+
+	if val1 := <-goodChan1; !reflect.DeepEqual(val1, &pl) {
+		t.Fatalf("expected %v, got %v", pl, val1)
+	}
+
+	t.Log("Test bad callback - invalid endpoint")
+	values = url.Values{
+		"callback": []string{
+			url.QueryEscape(srv.URL + goodEndpoint1),
+			url.QueryEscape(srv.URL + badEndpoint),
+		},
+	}
+	cb, err = parseCallback(values)
+	if err != nil {
+		t.Fatalf("unexpected error when getting callback for bad endpoint: %v", err)
+	}
+	pl = payload{Key: "e", Val: "f"}
+	if err := cb(ctx, pl); err == nil {
+		t.Fatalf("expected error when calling bad endpoint callback")
+	}
+
+	if val1 := <-goodChan1; !reflect.DeepEqual(val1, &pl) {
+		t.Fatalf("expected %v, got %v", pl, val1)
+	}
+
+	t.Log("Test nil context error")
+	values = url.Values{
+		"callback": []string{
+			url.QueryEscape(srv.URL + goodEndpoint1),
+		},
+	}
+	cb, err = parseCallback(values)
+	if err != nil {
+		t.Fatalf("unexpected error when getting callback for good endpoint: %v", err)
+	}
+	pl = payload{}
+	if err := cb(nil, pl); err == nil {
+		t.Fatalf("expected error when passing nil context to callback function")
+	}
+
+	t.Log("Test bad payload")
+	type recursive struct {
+		Ref *recursive `json:"Ref"`
+	}
+	badPl := recursive{}
+	badPl.Ref = &badPl
+	if err := cb(ctx, badPl); err == nil {
+		t.Fatalf("expected error when passing unmarshalable payload")
+	}
+}


### PR DESCRIPTION
Add callbacks query param, which can be used by clients to the server for notifications on completion of an asynchronous operation.

Callback support is added to the following endpoints:

    /backup/create
    /backup/upload/{name}
    /backup/download/{name}
    /backup/restore/{name}

The callback parameter can be passed to the target endpoint with the addition of

?callback={URI Encoded Callback URL}

Callback payloads are POSTed with the JSON serialized struct CallbackResponse, which is exported for use by clients. Multiple callback URLs can be specified; all URLs will be hit regardless of failures in any single endpoint.

Resolves AlexAkulov/clickhouse-backup#635