### PR TITLE
Solve connection leak issue in S3 backup remote delete on versioned buckets

### DIFF
--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -255,11 +255,11 @@ func (s *S3) isVersioningEnabled(ctx context.Context) bool {
 }
 
 func (s *S3) getObjectVersion(ctx context.Context, key string) (*string, error) {
-	params := &s3.GetObjectInput{
+	params := &s3.GetObjectAttributesInput{
 		Bucket: aws.String(s.Config.Bucket),
 		Key:    aws.String(path.Join(s.Config.Path, key)),
 	}
-	object, err := s.client.GetObject(ctx, params)
+	object, err := s.client.GetObjectAttributes(ctx, params)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I'm experiencing a connection leak issue on clickhouse-backup where the no. of open connections in the container grow by the thousands each time a 'remote delete' command on s3 is being executed. After a few days, the node would exhaust the TCP memory and drop almost all new TCP connections to it.

Clickhouse-backup version is`altinity/clickhouse-backup:2.1.3`.
I'm running Clickhouse on EKS with Clickhouse operator, EKS AMI for arm64 1.25.7-20230406 with linux kernel 5.10.
I noticed that the number of created connections is roughly equal to the number of objects being deleted for that shard/day. **My backups are uploaded to a versioned S3 bucket.**

I believe the bug is in getObjectVersion(): [s3.GetObject()](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#Client.GetObject) actually retrieves the object's body, which create a new connection until you close it.

Use [s3.GetObjectAttributes()](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#Client.GetObjectAttributes) (which is also cheaper than s3.GetObject) to retrieve the object's version.

/cc @Slach who kindly assisted in troubleshooting!