### PR TITLE
fixup 2cdaee68, use s3.HeadObject instead of s3.GetObjectAttributes

### DIFF
--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -255,11 +255,11 @@ func (s *S3) isVersioningEnabled(ctx context.Context) bool {
 }
 
 func (s *S3) getObjectVersion(ctx context.Context, key string) (*string, error) {
-	params := &s3.GetObjectAttributesInput{
+	params := &s3.HeadObjectInput{
 		Bucket: aws.String(s.Config.Bucket),
 		Key:    aws.String(path.Join(s.Config.Path, key)),
 	}
-	object, err := s.client.GetObjectAttributes(ctx, params)
+	object, err := s.client.HeadObject(ctx, params)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In my previous PR `GetObjectAttributes` is used incorrectly (a required argument is missing), and throws an error on the first object when deleting a remote backup on a versioned S3 bucket.

Here [HeadObject](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/s3#Client.HeadObject) is used instead, which is the recommended method to retrieve the current version ID of a versioned object.
I was able to test locally that it works correctly on a versioned bucket.

This replaces #637 