### PR TITLE
backup: Return nil error for delete of nonexistent directory

### DIFF
--- a/pkg/backup/delete.go
+++ b/pkg/backup/delete.go
@@ -3,11 +3,6 @@ package backup
 import (
 	"context"
 	"fmt"
-	"github.com/Altinity/clickhouse-backup/pkg/custom"
-	"github.com/Altinity/clickhouse-backup/pkg/status"
-	"github.com/Altinity/clickhouse-backup/pkg/storage/object_disk"
-	"github.com/Altinity/clickhouse-backup/pkg/utils"
-	"github.com/pkg/errors"
 	"io/fs"
 	"os"
 	"path"
@@ -16,9 +11,14 @@ import (
 	"time"
 
 	"github.com/Altinity/clickhouse-backup/pkg/clickhouse"
+	"github.com/Altinity/clickhouse-backup/pkg/custom"
+	"github.com/Altinity/clickhouse-backup/pkg/status"
 	"github.com/Altinity/clickhouse-backup/pkg/storage"
+	"github.com/Altinity/clickhouse-backup/pkg/storage/object_disk"
+	"github.com/Altinity/clickhouse-backup/pkg/utils"
 
 	apexLog "github.com/apex/log"
+	"github.com/pkg/errors"
 )
 
 // Clean - removed all data in shadow folder
@@ -48,6 +48,9 @@ func (b *Backuper) Clean(ctx context.Context) error {
 
 func (b *Backuper) cleanDir(dirName string) error {
 	if items, err := os.ReadDir(dirName); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	} else {
 		for _, item := range items {

--- a/pkg/backup/delete_test.go
+++ b/pkg/backup/delete_test.go
@@ -1,0 +1,37 @@
+package backup
+
+import (
+	"os"
+	"path"
+	"testing"
+)
+
+func TestCleanDir(t *testing.T) {
+	t.Run("Test deletion of nonexistent directory",
+		func(t *testing.T) {
+			b := &Backuper{}
+
+			dir := path.Join(t.TempDir(), t.Name(), "does-not-exist")
+			if err := b.cleanDir(dir); err != nil {
+				t.Fatalf("unexpected error when deleting nonexistent dir: %v", err)
+			}
+		},
+	)
+
+	t.Run("Test deletion of existing directory",
+		func(t *testing.T) {
+			b := &Backuper{}
+
+			dir := t.TempDir()
+			if err := os.MkdirAll(dir, 0644); err != nil {
+				t.Fatalf("unexpected error while creating temporary directory: %v", err)
+			}
+			if err := b.cleanDir(dir); err != nil {
+				t.Fatalf("unexpected error while deleting existing dir: %v", err)
+			}
+			if err := b.cleanDir(dir); err != nil {
+				t.Fatalf("unexpected error during back to back invocation of delete: %v", err)
+			}
+		},
+	)
+}


### PR DESCRIPTION
Make it so that deleting a directory is idempotent, returning a nil error if the directory is already deleted. This makes it so that one can call the Clean function in a way that it ensures the local state is clean rather than needing to be concerned about whether or not the shadow directory is existent at the time.

Fixes #686