### PR TITLE
fix too strict `system.parts_columns` check when backup create,

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ IMPROVEMENTS
 
 BUG FIXES
 - fix possible create backup failures during UNFREEZE not exists tables, affected 2.2.7+ version, fix [704](https://github.com/Altinity/clickhouse-backup/issues/704)
+- fix too strict `system.parts_columns` check when backup create, exclude Enum and Tuple (JSON) and Nullable(Type) vs Type corner cases, fix [685](https://github.com/Altinity/clickhouse-backup/issues/685), fix [699](https://github.com/Altinity/clickhouse-backup/issues/699)  
 
 # v2.3.2
 BUG FIXES


### PR DESCRIPTION
exclude Enum and Tuple (JSON) and Nullable(Type) vs Type corner cases

fix https://github.com/Altinity/clickhouse-backup/issues/685
fix https://github.com/Altinity/clickhouse-backup/issues/699