### PR TITLE
mention s3:GetBucketVersioning permission in README

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -756,7 +756,10 @@ In order to make backups to S3, the following permissions shall be set:
         {
             "Sid": "clickhouse-backup-s3-access-to-bucket",
             "Effect": "Allow",
-            "Action": "s3:ListBucket",
+            "Action": [
+                "s3:ListBucket",
+                "s3:GetBucketVersioning"
+            ],
             "Resource": "arn:aws:s3:::BUCKET_NAME"
         }
     ]


### PR DESCRIPTION
https://github.com/Altinity/clickhouse-backup/pull/556 added a check if S3 bucket versioning is enabled, but this requires its own IAM permission.

Without this permissions there are periodic `AccessDenied` errors in logs while making `GET /?versioning= HTTP/1.1` from isVersioningEnabled() though they appear to be harmless if versioning isn't being used.