### PR TITLE
Improve GCP uploading

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -509,6 +509,7 @@ gcs:
   # GCS_CUSTOM_STORAGE_CLASS_MAP, allow setup storage class depends on backup name regexp pattern, format nameRegexp > className
   custom_storage_class_map: {}
   debug: false                 # GCS_DEBUG
+  force_http: false            # GCS_FORCE_HTTP
 cos:
   url: ""                      # COS_URL
   timeout: 2m                  # COS_TIMEOUT

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -75,6 +75,7 @@ type GCSConfig struct {
 	CompressionLevel       int               `yaml:"compression_level" envconfig:"GCS_COMPRESSION_LEVEL"`
 	CompressionFormat      string            `yaml:"compression_format" envconfig:"GCS_COMPRESSION_FORMAT"`
 	Debug                  bool              `yaml:"debug" envconfig:"GCS_DEBUG"`
+	ForceHttp              bool              `yaml:"force_http" envconfig:"GCS_FORCE_HTTP"`
 	Endpoint               string            `yaml:"endpoint" envconfig:"GCS_ENDPOINT"`
 	StorageClass           string            `yaml:"storage_class" envconfig:"GCS_STORAGE_CLASS"`
 	ObjectLabels           map[string]string `yaml:"object_labels" envconfig:"GCS_OBJECT_LABELS"`


### PR DESCRIPTION
thanks Andrew W for the contribution.

The PR include 2 fix:
- GCP upload need to return the error, currently it cannot catch upload error and retry, because the error is handle in defer and never return to caller, so it will fail at the first failure.
- Add support for HTTP reverse proxy handling, if the flag force_http is set to true it will use http reverse proxy. 