### PR TITLE
Change watch start behavior for respect last backup time and type

### DIFF
--- a/pkg/backup/watch.go
+++ b/pkg/backup/watch.go
@@ -115,7 +115,11 @@ func (b *Backuper) Watch(watchInterval, fullInterval, watchBackupNameTemplate, t
 		b.log.Infof("Time before do full backup %v", timeBeforeDoFullBackup)
 		if timeBeforeDoBackup > 0 && timeBeforeDoFullBackup > 0 {
 			b.log.Infof("Waiting %d seconds until continue doing backups due watch interval", timeBeforeDoBackup)
-			time.Sleep(b.cfg.General.WatchDuration - now.Sub(lastBackup))
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(b.cfg.General.WatchDuration - now.Sub(lastBackup)):
+			}
 		}
 		now = time.Now()
 		lastBackup = now

--- a/pkg/backup/watch.go
+++ b/pkg/backup/watch.go
@@ -91,7 +91,7 @@ func (b *Backuper) Watch(watchInterval, fullInterval, watchBackupNameTemplate, t
 	if err != nil {
 		return err
 	}
-	backupTemplateNamePrepR := regexp.MustCompile(`\{type\}|\{time:[\S\s]+\}`)
+	backupTemplateNamePrepR := regexp.MustCompile(`{type}|{time:([^}]+)}`)
 	backupTemplateNameR := regexp.MustCompile(backupTemplateNamePrepR.ReplaceAllString(backupTemplateName, `\S+`))
 
 	for _, remoteBackup := range remoteBackups {
@@ -111,13 +111,17 @@ func (b *Backuper) Watch(watchInterval, fullInterval, watchBackupNameTemplate, t
 		now := time.Now()
 		timeBeforeDoBackup := int(b.cfg.General.WatchDuration.Seconds() - now.Sub(lastBackup).Seconds())
 		timeBeforeDoFullBackup := int(b.cfg.General.FullDuration.Seconds() - now.Sub(lastFullBackup).Seconds())
+		b.log.Infof("Time before do backup %v", timeBeforeDoBackup)
+		b.log.Infof("Time before do full backup %v", timeBeforeDoFullBackup)
 		if timeBeforeDoBackup > 0 && timeBeforeDoFullBackup > 0 {
 			b.log.Infof("Wainting %d seconds until continue doing backups due watch interval", timeBeforeDoBackup)
 			time.Sleep(b.cfg.General.WatchDuration - now.Sub(lastBackup))
 		}
-		lastBackup = time.Now()
+		now = time.Now()
+		lastBackup = now
 		if b.cfg.General.FullDuration.Seconds()-time.Now().Sub(lastFullBackup).Seconds() <= 0 {
 			backupType = "full"
+			lastFullBackup = now
 		} else {
 			backupType = "increment"
 		}

--- a/pkg/backup/watch.go
+++ b/pkg/backup/watch.go
@@ -114,7 +114,7 @@ func (b *Backuper) Watch(watchInterval, fullInterval, watchBackupNameTemplate, t
 		b.log.Infof("Time before do backup %v", timeBeforeDoBackup)
 		b.log.Infof("Time before do full backup %v", timeBeforeDoFullBackup)
 		if timeBeforeDoBackup > 0 && timeBeforeDoFullBackup > 0 {
-			b.log.Infof("Wainting %d seconds until continue doing backups due watch interval", timeBeforeDoBackup)
+			b.log.Infof("Waiting %d seconds until continue doing backups due watch interval", timeBeforeDoBackup)
 			time.Sleep(b.cfg.General.WatchDuration - now.Sub(lastBackup))
 		}
 		now = time.Now()

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -785,7 +785,7 @@ func testAPIWatchAndKill(r *require.Assertions, ch *TestClickHouse) {
 	r.NoError(err)
 	time.Sleep(7 * time.Second)
 
-	checkWatchBackup(2)
+	checkWatchBackup(1)
 	runKillCommand("watch")
 	checkCanceledCommand(2)
 }


### PR DESCRIPTION
I make my backups with systemd service and timer using watch functionality.
There was big surprise, that any service (clickhouse-backup) restart by any reason triggers new full backup, that in my case continues ~20 hours and lead to higher backup storage consumption.
I changed this behavior by adding timeout on start and define next backup type full or increment.