### PR TITLE
docs: remove suffix -race from usage documentation

### DIFF
--- a/Manual.md
+++ b/Manual.md
@@ -1,7 +1,7 @@
 ### CLI command - tables
 ```
 NAME:
-   clickhouse-backup-race tables - List of tables, exclude skip_tables
+   clickhouse-backup tables - List of tables, exclude skip_tables
 
 USAGE:
    clickhouse-backup tables [-t, --tables=<db>.<table>]] [--all]
@@ -15,7 +15,7 @@ OPTIONS:
 ### CLI command - create
 ```
 NAME:
-   clickhouse-backup-race create - Create new backup
+   clickhouse-backup create - Create new backup
 
 USAGE:
    clickhouse-backup create [-t, --tables=<db>.<table>] [--partitions=<partition_names>] [-s, --schema] [--rbac] [--configs] [--skip-check-parts-columns] <backup_name>
@@ -43,7 +43,7 @@ Look at the system.parts partition and partition_id fields for details https://c
 ### CLI command - create_remote
 ```
 NAME:
-   clickhouse-backup-race create_remote - Create and upload new backup
+   clickhouse-backup create_remote - Create and upload new backup
 
 USAGE:
    clickhouse-backup create_remote [-t, --tables=<db>.<table>] [--partitions=<partition_names>] [--diff-from=<local_backup_name>] [--diff-from-remote=<local_backup_name>] [--schema] [--rbac] [--configs] [--resumable] [--skip-check-parts-columns] <backup_name>
@@ -74,7 +74,7 @@ Look at the system.parts partition and partition_id fields for details https://c
 ### CLI command - upload
 ```
 NAME:
-   clickhouse-backup-race upload - Upload backup to remote storage
+   clickhouse-backup upload - Upload backup to remote storage
 
 USAGE:
    clickhouse-backup upload [-t, --tables=<db>.<table>] [--partitions=<partition_names>] [-s, --schema] [--diff-from=<local_backup_name>] [--diff-from-remote=<remote_backup_name>] [--resumable] <backup_name>
@@ -97,7 +97,7 @@ Look at the system.parts partition and partition_id fields for details https://c
 ### CLI command - list
 ```
 NAME:
-   clickhouse-backup-race list - List of backups
+   clickhouse-backup list - List of backups
 
 USAGE:
    clickhouse-backup list [all|local|remote] [latest|previous]
@@ -109,7 +109,7 @@ OPTIONS:
 ### CLI command - download
 ```
 NAME:
-   clickhouse-backup-race download - Download backup from remote storage
+   clickhouse-backup download - Download backup from remote storage
 
 USAGE:
    clickhouse-backup download [-t, --tables=<db>.<table>] [--partitions=<partition_names>] [-s, --schema] [--resumable] <backup_name>
@@ -130,7 +130,7 @@ Look at the system.parts partition and partition_id fields for details https://c
 ### CLI command - restore
 ```
 NAME:
-   clickhouse-backup-race restore - Create schema and restore data from backup
+   clickhouse-backup restore - Create schema and restore data from backup
 
 USAGE:
    clickhouse-backup restore  [-t, --tables=<db>.<table>] [-m, --restore-database-mapping=<originDB>:<targetDB>[,<...>]] [--partitions=<partitions_names>] [-s, --schema] [-d, --data] [--rm, --drop] [-i, --ignore-dependencies] [--rbac] [--configs] <backup_name>
@@ -158,7 +158,7 @@ Look at the system.parts partition and partition_id fields for details https://c
 ### CLI command - restore_remote
 ```
 NAME:
-   clickhouse-backup-race restore_remote - Download and restore
+   clickhouse-backup restore_remote - Download and restore
 
 USAGE:
    clickhouse-backup restore_remote [--schema] [--data] [-t, --tables=<db>.<table>] [-m, --restore-database-mapping=<originDB>:<targetDB>[,<...>]] [--partitions=<partitions_names>] [--rm, --drop] [-i, --ignore-dependencies] [--rbac] [--configs] [--skip-rbac] [--skip-configs] [--resumable] <backup_name>
@@ -187,7 +187,7 @@ Look at the system.parts partition and partition_id fields for details https://c
 ### CLI command - delete
 ```
 NAME:
-   clickhouse-backup-race delete - Delete specific backup
+   clickhouse-backup delete - Delete specific backup
 
 USAGE:
    clickhouse-backup delete <local|remote> <backup_name>
@@ -199,10 +199,10 @@ OPTIONS:
 ### CLI command - default-config
 ```
 NAME:
-   clickhouse-backup-race default-config - Print default config
+   clickhouse-backup default-config - Print default config
 
 USAGE:
-   clickhouse-backup-race default-config [command options] [arguments...]
+   clickhouse-backup default-config [command options] [arguments...]
 
 OPTIONS:
    --config value, -c value  Config 'FILE' name. (default: "/etc/clickhouse-backup/config.yml") [$CLICKHOUSE_BACKUP_CONFIG]
@@ -211,10 +211,10 @@ OPTIONS:
 ### CLI command - print-config
 ```
 NAME:
-   clickhouse-backup-race print-config - Print current config merged with environment variables
+   clickhouse-backup print-config - Print current config merged with environment variables
 
 USAGE:
-   clickhouse-backup-race print-config [command options] [arguments...]
+   clickhouse-backup print-config [command options] [arguments...]
 
 OPTIONS:
    --config value, -c value  Config 'FILE' name. (default: "/etc/clickhouse-backup/config.yml") [$CLICKHOUSE_BACKUP_CONFIG]
@@ -223,10 +223,10 @@ OPTIONS:
 ### CLI command - clean
 ```
 NAME:
-   clickhouse-backup-race clean - Remove data in 'shadow' folder from all 'path' folders available from 'system.disks'
+   clickhouse-backup clean - Remove data in 'shadow' folder from all 'path' folders available from 'system.disks'
 
 USAGE:
-   clickhouse-backup-race clean [command options] [arguments...]
+   clickhouse-backup clean [command options] [arguments...]
 
 OPTIONS:
    --config value, -c value  Config 'FILE' name. (default: "/etc/clickhouse-backup/config.yml") [$CLICKHOUSE_BACKUP_CONFIG]
@@ -235,10 +235,10 @@ OPTIONS:
 ### CLI command - clean_remote_broken
 ```
 NAME:
-   clickhouse-backup-race clean_remote_broken - Remove all broken remote backups
+   clickhouse-backup clean_remote_broken - Remove all broken remote backups
 
 USAGE:
-   clickhouse-backup-race clean_remote_broken [command options] [arguments...]
+   clickhouse-backup clean_remote_broken [command options] [arguments...]
 
 OPTIONS:
    --config value, -c value  Config 'FILE' name. (default: "/etc/clickhouse-backup/config.yml") [$CLICKHOUSE_BACKUP_CONFIG]
@@ -247,7 +247,7 @@ OPTIONS:
 ### CLI command - watch
 ```
 NAME:
-   clickhouse-backup-race watch - Run infinite loop which create full + incremental backup sequence to allow efficient backup sequences
+   clickhouse-backup watch - Run infinite loop which create full + incremental backup sequence to allow efficient backup sequences
 
 USAGE:
    clickhouse-backup watch [--watch-interval=1h] [--full-interval=24h] [--watch-backup-name-template=shard{shard}-{type}-{time:20060102150405}] [-t, --tables=<db>.<table>] [--partitions=<partitions_names>] [--schema] [--rbac] [--configs] [--skip-check-parts-columns]
@@ -276,10 +276,10 @@ Look at the system.parts partition and partition_id fields for details https://c
 ### CLI command - server
 ```
 NAME:
-   clickhouse-backup-race server - Run API server
+   clickhouse-backup server - Run API server
 
 USAGE:
-   clickhouse-backup-race server [command options] [arguments...]
+   clickhouse-backup server [command options] [arguments...]
 
 OPTIONS:
    --config value, -c value            Config 'FILE' name. (default: "/etc/clickhouse-backup/config.yml") [$CLICKHOUSE_BACKUP_CONFIG]

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -80,7 +80,7 @@ More detailed description available here https://www.youtube.com/watch?v=megsNh9
 ### CLI command - tables
 ```
 NAME:
-   clickhouse-backup-race tables - List of tables, exclude skip_tables
+   clickhouse-backup tables - List of tables, exclude skip_tables
 
 USAGE:
    clickhouse-backup tables [-t, --tables=<db>.<table>]] [--all]
@@ -94,7 +94,7 @@ OPTIONS:
 ### CLI command - create
 ```
 NAME:
-   clickhouse-backup-race create - Create new backup
+   clickhouse-backup create - Create new backup
 
 USAGE:
    clickhouse-backup create [-t, --tables=<db>.<table>] [--partitions=<partition_names>] [-s, --schema] [--rbac] [--configs] [--skip-check-parts-columns] <backup_name>
@@ -122,7 +122,7 @@ Look at the system.parts partition and partition_id fields for details https://c
 ### CLI command - create_remote
 ```
 NAME:
-   clickhouse-backup-race create_remote - Create and upload new backup
+   clickhouse-backup create_remote - Create and upload new backup
 
 USAGE:
    clickhouse-backup create_remote [-t, --tables=<db>.<table>] [--partitions=<partition_names>] [--diff-from=<local_backup_name>] [--diff-from-remote=<local_backup_name>] [--schema] [--rbac] [--configs] [--resumable] [--skip-check-parts-columns] <backup_name>
@@ -153,7 +153,7 @@ Look at the system.parts partition and partition_id fields for details https://c
 ### CLI command - upload
 ```
 NAME:
-   clickhouse-backup-race upload - Upload backup to remote storage
+   clickhouse-backup upload - Upload backup to remote storage
 
 USAGE:
    clickhouse-backup upload [-t, --tables=<db>.<table>] [--partitions=<partition_names>] [-s, --schema] [--diff-from=<local_backup_name>] [--diff-from-remote=<remote_backup_name>] [--resumable] <backup_name>
@@ -176,7 +176,7 @@ Look at the system.parts partition and partition_id fields for details https://c
 ### CLI command - list
 ```
 NAME:
-   clickhouse-backup-race list - List of backups
+   clickhouse-backup list - List of backups
 
 USAGE:
    clickhouse-backup list [all|local|remote] [latest|previous]
@@ -188,7 +188,7 @@ OPTIONS:
 ### CLI command - download
 ```
 NAME:
-   clickhouse-backup-race download - Download backup from remote storage
+   clickhouse-backup download - Download backup from remote storage
 
 USAGE:
    clickhouse-backup download [-t, --tables=<db>.<table>] [--partitions=<partition_names>] [-s, --schema] [--resumable] <backup_name>
@@ -209,7 +209,7 @@ Look at the system.parts partition and partition_id fields for details https://c
 ### CLI command - restore
 ```
 NAME:
-   clickhouse-backup-race restore - Create schema and restore data from backup
+   clickhouse-backup restore - Create schema and restore data from backup
 
 USAGE:
    clickhouse-backup restore  [-t, --tables=<db>.<table>] [-m, --restore-database-mapping=<originDB>:<targetDB>[,<...>]] [--partitions=<partitions_names>] [-s, --schema] [-d, --data] [--rm, --drop] [-i, --ignore-dependencies] [--rbac] [--configs] <backup_name>
@@ -237,7 +237,7 @@ Look at the system.parts partition and partition_id fields for details https://c
 ### CLI command - restore_remote
 ```
 NAME:
-   clickhouse-backup-race restore_remote - Download and restore
+   clickhouse-backup restore_remote - Download and restore
 
 USAGE:
    clickhouse-backup restore_remote [--schema] [--data] [-t, --tables=<db>.<table>] [-m, --restore-database-mapping=<originDB>:<targetDB>[,<...>]] [--partitions=<partitions_names>] [--rm, --drop] [-i, --ignore-dependencies] [--rbac] [--configs] [--skip-rbac] [--skip-configs] [--resumable] <backup_name>
@@ -266,7 +266,7 @@ Look at the system.parts partition and partition_id fields for details https://c
 ### CLI command - delete
 ```
 NAME:
-   clickhouse-backup-race delete - Delete specific backup
+   clickhouse-backup delete - Delete specific backup
 
 USAGE:
    clickhouse-backup delete <local|remote> <backup_name>
@@ -278,10 +278,10 @@ OPTIONS:
 ### CLI command - default-config
 ```
 NAME:
-   clickhouse-backup-race default-config - Print default config
+   clickhouse-backup default-config - Print default config
 
 USAGE:
-   clickhouse-backup-race default-config [command options] [arguments...]
+   clickhouse-backup default-config [command options] [arguments...]
 
 OPTIONS:
    --config value, -c value  Config 'FILE' name. (default: "/etc/clickhouse-backup/config.yml") [$CLICKHOUSE_BACKUP_CONFIG]
@@ -290,10 +290,10 @@ OPTIONS:
 ### CLI command - print-config
 ```
 NAME:
-   clickhouse-backup-race print-config - Print current config merged with environment variables
+   clickhouse-backup print-config - Print current config merged with environment variables
 
 USAGE:
-   clickhouse-backup-race print-config [command options] [arguments...]
+   clickhouse-backup print-config [command options] [arguments...]
 
 OPTIONS:
    --config value, -c value  Config 'FILE' name. (default: "/etc/clickhouse-backup/config.yml") [$CLICKHOUSE_BACKUP_CONFIG]
@@ -302,10 +302,10 @@ OPTIONS:
 ### CLI command - clean
 ```
 NAME:
-   clickhouse-backup-race clean - Remove data in 'shadow' folder from all 'path' folders available from 'system.disks'
+   clickhouse-backup clean - Remove data in 'shadow' folder from all 'path' folders available from 'system.disks'
 
 USAGE:
-   clickhouse-backup-race clean [command options] [arguments...]
+   clickhouse-backup clean [command options] [arguments...]
 
 OPTIONS:
    --config value, -c value  Config 'FILE' name. (default: "/etc/clickhouse-backup/config.yml") [$CLICKHOUSE_BACKUP_CONFIG]
@@ -314,10 +314,10 @@ OPTIONS:
 ### CLI command - clean_remote_broken
 ```
 NAME:
-   clickhouse-backup-race clean_remote_broken - Remove all broken remote backups
+   clickhouse-backup clean_remote_broken - Remove all broken remote backups
 
 USAGE:
-   clickhouse-backup-race clean_remote_broken [command options] [arguments...]
+   clickhouse-backup clean_remote_broken [command options] [arguments...]
 
 OPTIONS:
    --config value, -c value  Config 'FILE' name. (default: "/etc/clickhouse-backup/config.yml") [$CLICKHOUSE_BACKUP_CONFIG]
@@ -326,7 +326,7 @@ OPTIONS:
 ### CLI command - watch
 ```
 NAME:
-   clickhouse-backup-race watch - Run infinite loop which create full + incremental backup sequence to allow efficient backup sequences
+   clickhouse-backup watch - Run infinite loop which create full + incremental backup sequence to allow efficient backup sequences
 
 USAGE:
    clickhouse-backup watch [--watch-interval=1h] [--full-interval=24h] [--watch-backup-name-template=shard{shard}-{type}-{time:20060102150405}] [-t, --tables=<db>.<table>] [--partitions=<partitions_names>] [--schema] [--rbac] [--configs] [--skip-check-parts-columns]
@@ -355,10 +355,10 @@ Look at the system.parts partition and partition_id fields for details https://c
 ### CLI command - server
 ```
 NAME:
-   clickhouse-backup-race server - Run API server
+   clickhouse-backup server - Run API server
 
 USAGE:
-   clickhouse-backup-race server [command options] [arguments...]
+   clickhouse-backup server [command options] [arguments...]
 
 OPTIONS:
    --config value, -c value            Config 'FILE' name. (default: "/etc/clickhouse-backup/config.yml") [$CLICKHOUSE_BACKUP_CONFIG]


### PR DESCRIPTION
Remove this suffix `-race` from usage doc as the binary apparently doesn't have this `-race` suffix.

Test from docker image **altinity/clickhouse-backup:2.4.17**:
```
ca0659cd2951:/# ls -lah /bin | grep clickhouse
-rwxr-xr-x    1 root     root       46.8M Jan  9 16:13 clickhouse-backup
ca0659cd2951:/# which clickhouse
```

Note: this is my first time opening PR to this repository, so appreciate any feedback!  