### PR TITLE
fix: gcs endpoint should be independently configured with credential

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -529,6 +529,7 @@ gcs:
   credentials_file: ""         # GCS_CREDENTIALS_FILE
   credentials_json: ""         # GCS_CREDENTIALS_JSON
   credentials_json_encoded: "" # GCS_CREDENTIALS_JSON_ENCODED
+  endpoint: ""                 # GCS_ENDPOINT, use it for custom GCS endpoint/compatible storage. For example, when using custom endpoint via private service connect
   bucket: ""                   # GCS_BUCKET
   path: ""                     # GCS_PATH, `system.macros` values can be applied as {macro_name}
   object_disk_path: ""         # GCS_OBJECT_DISK_PATH, path for backup of part from `s3` object disk (clickhouse support only gcs over s3 protocol), if disk present, then shall not be zero and shall not be prefixed by `path`

--- a/pkg/storage/gcs.go
+++ b/pkg/storage/gcs.go
@@ -90,15 +90,18 @@ func (gcs *GCS) Connect(ctx context.Context) error {
 
 	if gcs.Config.Endpoint != "" {
 		endpoint = gcs.Config.Endpoint
-		clientOptions = append([]option.ClientOption{option.WithoutAuthentication()}, clientOptions...)
 		clientOptions = append(clientOptions, option.WithEndpoint(endpoint))
-	} else if gcs.Config.CredentialsJSON != "" {
+	}
+
+	if gcs.Config.CredentialsJSON != "" {
 		clientOptions = append(clientOptions, option.WithCredentialsJSON([]byte(gcs.Config.CredentialsJSON)))
 	} else if gcs.Config.CredentialsJSONEncoded != "" {
 		d, _ := base64.StdEncoding.DecodeString(gcs.Config.CredentialsJSONEncoded)
 		clientOptions = append(clientOptions, option.WithCredentialsJSON(d))
 	} else if gcs.Config.CredentialsFile != "" {
 		clientOptions = append(clientOptions, option.WithCredentialsFile(gcs.Config.CredentialsFile))
+	} else {
+		clientOptions = append(clientOptions, option.WithoutAuthentication())
 	}
 
 	if gcs.Config.ForceHttp {

--- a/test/integration/config-gcs-custom-endpoint.yml
+++ b/test/integration/config-gcs-custom-endpoint.yml
@@ -1,0 +1,29 @@
+general:
+  disable_progress_bar: true
+  remote_storage: gcs
+  upload_concurrency: 4
+  download_concurrency: 4
+  skip_tables:
+    - " system.*"
+    - "INFORMATION_SCHEMA.*"
+    - "information_schema.*"
+    - "_temporary_and_external_tables.*"
+  restore_schema_on_cluster: "{cluster}"
+clickhouse:
+  host: clickhouse
+  port: 9440
+  username: backup
+  password: meow=& 123?*%# МЯУ
+  secure: true
+  skip_verify: true
+  sync_replicated_tables: true
+  timeout: 5s
+  restart_command: "sql:SYSTEM RELOAD USERS; sql:SYSTEM RELOAD CONFIG; exec:ls -la /var/lib/clickhouse/access; sql:SYSTEM SHUTDOWN"
+  # restart_command: bash -c 'echo "FAKE RESTART"'
+  backup_mutations: true
+gcs:
+  bucket: altinity-qa-test
+  path: backup/{cluster}/{shard}
+  object_disk_path: object_disks/{cluster}/{shard}
+  compression_format: tar
+  endpoint: http://gcs:8080/storage/v1/

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -43,17 +43,18 @@ services:
       - clickhouse-backup
 
 # todo need to reproduce download after upload
-#  gcs:
-#    image: fsouza/fake-gcs-server:latest
-#    hostname: gcs
-#    entrypoint:
-#      - /bin/sh
-#    command:
-#      - -c
-#      - "mkdir -p /data/clickhouse-backup-test-gcs && fake-gcs-server -data /data -scheme http -port 8080 -public-host gsc:8080"
-#    networks:
-#      - clickhouse-backup
-
+  gcs:
+    image: fsouza/fake-gcs-server:latest
+    hostname: gcs
+    entrypoint:
+      - /bin/sh
+    command:
+      - -c
+      - "mkdir -p /data/altinity-qa-test && mkdir -p /data/${QA_GCS_OVER_S3_BUCKET} && fake-gcs-server -data /data -scheme http -port 8080 -public-host gcs:8080"
+    networks:
+      - clickhouse-backup
+    environment:
+      QA_GCS_OVER_S3_BUCKET: "${QA_GCS_OVER_S3_BUCKET}"
 
   azure:
     image: mcr.microsoft.com/azure-storage/azurite:latest
@@ -126,9 +127,6 @@ services:
       AZBLOB_DEBUG: "${AZBLOB_DEBUG:-false}"
       CLICKHOUSE_DEBUG: "${CLICKHOUSE_DEBUG:-false}"
       GOCOVERDIR: "/tmp/_coverage_/"
-# fake-gcs-server
-#       STORAGE_EMULATOR_HOST: "http://gsc:8080"
-#       GOOGLE_API_USE_CLIENT_CERTIFICATE: "false"
 # FIPS
       QA_AWS_ACCESS_KEY: ${QA_AWS_ACCESS_KEY}
       QA_AWS_SECRET_KEY: ${QA_AWS_SECRET_KEY}
@@ -166,9 +164,6 @@ services:
       AZBLOB_DEBUG: "${AZBLOB_DEBUG:-false}"
       CLICKHOUSE_DEBUG: "${CLICKHOUSE_DEBUG:-false}"
       GOCOVERDIR: "/tmp/_coverage_/"
-# fake-gcs-server
-#       STORAGE_EMULATOR_HOST: "http://gsc:8080"
-#       GOOGLE_API_USE_CLIENT_CERTIFICATE: "false"
 # FIPS
       QA_AWS_ACCESS_KEY: ${QA_AWS_ACCESS_KEY}
       QA_AWS_SECRET_KEY: ${QA_AWS_SECRET_KEY}
@@ -196,6 +191,7 @@ services:
       - ./config-ftp.yaml:/etc/clickhouse-backup/config-ftp.yaml
       - ./config-ftp-old.yaml:/etc/clickhouse-backup/config-ftp-old.yaml
       - ./config-gcs.yml:/etc/clickhouse-backup/config-gcs.yml
+      - ./config-gcs-custom-endpoint.yml:/etc/clickhouse-backup/config-gcs-custom-endpoint.yml
       - ./config-s3.yml:/etc/clickhouse-backup/config-s3.yml
       - ./config-s3-embedded.yml:/etc/clickhouse-backup/config-s3-embedded.yml
       - ./config-s3-fips.yml:/etc/clickhouse-backup/config-s3-fips.yml.template

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -46,6 +46,7 @@ services:
   gcs:
     image: fsouza/fake-gcs-server:latest
     hostname: gcs
+    container_name: gcs
     entrypoint:
       - /bin/sh
     command:

--- a/test/integration/docker-compose_advanced.yml
+++ b/test/integration/docker-compose_advanced.yml
@@ -60,6 +60,7 @@ services:
   gcs:
     image: fsouza/fake-gcs-server:latest
     hostname: gcs
+    container_name: gcs
     entrypoint:
       - /bin/sh
     command:

--- a/test/integration/docker-compose_advanced.yml
+++ b/test/integration/docker-compose_advanced.yml
@@ -57,17 +57,18 @@ services:
       - clickhouse-backup
 
 # todo need to reproduce download after upload
-#  gcs:
-#    image: fsouza/fake-gcs-server:latest
-#    hostname: gcs
-#    entrypoint:
-#      - /bin/sh
-#    command:
-#      - -c
-#      - "mkdir -p /data/clickhouse-backup-test-gcs && fake-gcs-server -data /data -scheme http -port 8080 -public-host gsc:8080"
-#    networks:
-#      - clickhouse-backup
-
+  gcs:
+    image: fsouza/fake-gcs-server:latest
+    hostname: gcs
+    entrypoint:
+      - /bin/sh
+    command:
+      - -c
+      - "mkdir -p /data/altinity-qa-test && mkdir -p /data/${QA_GCS_OVER_S3_BUCKET} && fake-gcs-server -data /data -scheme http -port 8080 -public-host gcs:8080"
+    networks:
+      - clickhouse-backup
+    environment:
+      QA_GCS_OVER_S3_BUCKET: "${QA_GCS_OVER_S3_BUCKET}"
 
   azure:
     image: mcr.microsoft.com/azure-storage/azurite:latest
@@ -177,9 +178,6 @@ services:
       AZBLOB_DEBUG: "${AZBLOB_DEBUG:-false}"
       CLICKHOUSE_DEBUG: "${CLICKHOUSE_DEBUG:-false}"
       GOCOVERDIR: "/tmp/_coverage_/"
-# fake-gcs-server
-#       STORAGE_EMULATOR_HOST: "http://gsc:8080"
-#       GOOGLE_API_USE_CLIENT_CERTIFICATE: "false"
 # FIPS
       QA_AWS_ACCESS_KEY: ${QA_AWS_ACCESS_KEY}
       QA_AWS_SECRET_KEY: ${QA_AWS_SECRET_KEY}
@@ -217,9 +215,6 @@ services:
       AZBLOB_DEBUG: "${AZBLOB_DEBUG:-false}"
       CLICKHOUSE_DEBUG: "${CLICKHOUSE_DEBUG:-false}"
       GOCOVERDIR: "/tmp/_coverage_/"
-# fake-gcs-server
-#       STORAGE_EMULATOR_HOST: "http://gsc:8080"
-#       GOOGLE_API_USE_CLIENT_CERTIFICATE: "false"
 # FIPS
       QA_AWS_ACCESS_KEY: ${QA_AWS_ACCESS_KEY}
       QA_AWS_SECRET_KEY: ${QA_AWS_SECRET_KEY}
@@ -254,6 +249,7 @@ services:
       - ./config-ftp.yaml:/etc/clickhouse-backup/config-ftp.yaml
       - ./config-ftp-old.yaml:/etc/clickhouse-backup/config-ftp-old.yaml
       - ./config-gcs.yml:/etc/clickhouse-backup/config-gcs.yml
+      - ./config-gcs-custom-endpoint.yml:/etc/clickhouse-backup/config-gcs-custom-endpoint.yml
       - ./config-s3.yml:/etc/clickhouse-backup/config-s3.yml
       - ./config-s3-embedded.yml:/etc/clickhouse-backup/config-s3-embedded.yml
       - ./config-s3-fips.yml:/etc/clickhouse-backup/config-s3-fips.yml.template

--- a/test/integration/dynamic_settings.sh
+++ b/test/integration/dynamic_settings.sh
@@ -130,12 +130,14 @@ cat <<EOT > /etc/clickhouse-server/config.d/storage_configuration_gcs.xml
     <disks>
       <disk_gcs>
         <type>s3</type>
-        <endpoint>https://storage.googleapis.com/${QA_GCS_OVER_S3_BUCKET}/clickhouse_backup_disk_gcs_over_s3/${HOSTNAME}/{cluster}/{shard}/</endpoint>
-        <access_key_id>${QA_GCS_OVER_S3_ACCESS_KEY}</access_key_id>
-        <secret_access_key>${QA_GCS_OVER_S3_SECRET_KEY}</secret_access_key>
+        <endpoint>http://gcs:8080/${QA_GCS_OVER_S3_BUCKET}/disk_gcs/{cluster}/{shard}/</endpoint>
+        <!-- https://github.com/Altinity/clickhouse-backup/issues/691
+        <access_key_id>access-key</access_key_id>
+        <secret_access_key>it-is-my-super-secret-key</secret_access_key>
+        -->
+        <use_environment_credentials>1</use_environment_credentials>
         <!-- to avoid slow startup -->
         <send_metadata>false</send_metadata>
-        <support_batch_delete>false</support_batch_delete>
       </disk_gcs>
     </disks>
     <policies>

--- a/test/integration/dynamic_settings.sh
+++ b/test/integration/dynamic_settings.sh
@@ -130,14 +130,12 @@ cat <<EOT > /etc/clickhouse-server/config.d/storage_configuration_gcs.xml
     <disks>
       <disk_gcs>
         <type>s3</type>
-        <endpoint>http://gcs:8080/${QA_GCS_OVER_S3_BUCKET}/disk_gcs/{cluster}/{shard}/</endpoint>
-        <!-- https://github.com/Altinity/clickhouse-backup/issues/691
-        <access_key_id>access-key</access_key_id>
-        <secret_access_key>it-is-my-super-secret-key</secret_access_key>
-        -->
-        <use_environment_credentials>1</use_environment_credentials>
+        <endpoint>https://storage.googleapis.com/${QA_GCS_OVER_S3_BUCKET}/clickhouse_backup_disk_gcs_over_s3/${HOSTNAME}/{cluster}/{shard}/</endpoint>
+        <access_key_id>${QA_GCS_OVER_S3_ACCESS_KEY}</access_key_id>
+        <secret_access_key>${QA_GCS_OVER_S3_SECRET_KEY}</secret_access_key>
         <!-- to avoid slow startup -->
         <send_metadata>false</send_metadata>
+        <support_batch_delete>false</support_batch_delete>
       </disk_gcs>
     </disks>
     <policies>

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1720,6 +1720,15 @@ func TestIntegrationGCS(t *testing.T) {
 	runMainIntegrationScenario(t, "GCS", "config-gcs.yml")
 }
 
+func TestIntegrationGCSWithCustomEndpoint(t *testing.T) {
+	if isTestShouldSkip("GCS_TESTS") {
+		t.Skip("Skipping GCS integration tests...")
+		return
+	}
+	//t.Parallel()
+	runMainIntegrationScenario(t, "GCS", "config-gcs-custom-endpoint.yml")
+}
+
 func TestIntegrationSFTPAuthPassword(t *testing.T) {
 	//t.Parallel()
 	runMainIntegrationScenario(t, "SFTP", "config-sftp-auth-password.yaml")
@@ -2110,7 +2119,6 @@ func checkObjectStorageIsEmpty(t *testing.T, r *require.Assertions, remoteStorag
 	}
 	if remoteStorageType == "SFTP" {
 		checkRemoteDir("total 0", "sshd", "bash", "-c", "ls -lh /root/")
-
 	}
 	if remoteStorageType == "FTP" {
 		if strings.Contains(os.Getenv("COMPOSE_FILE"), "advanced") {
@@ -2119,9 +2127,8 @@ func checkObjectStorageIsEmpty(t *testing.T, r *require.Assertions, remoteStorag
 			checkRemoteDir("total 0", "ftp", "bash", "-c", "ls -lh /home/vsftpd/test_backup/backup/")
 		}
 	}
-	//todo check gcs backup is empty
 	if remoteStorageType == "GCS" {
-
+		checkRemoteDir("total 0", "gcs", "bash", "-c", "ls -lh /data/clickhouse-backup-test-gcs")
 	}
 }
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1726,7 +1726,7 @@ func TestIntegrationGCSWithCustomEndpoint(t *testing.T) {
 		return
 	}
 	//t.Parallel()
-	runMainIntegrationScenario(t, "GCS", "config-gcs-custom-endpoint.yml")
+	runMainIntegrationScenario(t, "GCS_EMULATOR", "config-gcs-custom-endpoint.yml")
 }
 
 func TestIntegrationSFTPAuthPassword(t *testing.T) {
@@ -2127,8 +2127,8 @@ func checkObjectStorageIsEmpty(t *testing.T, r *require.Assertions, remoteStorag
 			checkRemoteDir("total 0", "ftp", "bash", "-c", "ls -lh /home/vsftpd/test_backup/backup/")
 		}
 	}
-	if remoteStorageType == "GCS" {
-		checkRemoteDir("total 0", "gcs", "bash", "-c", "ls -lh /data/clickhouse-backup-test-gcs")
+	if remoteStorageType == "GCS_EMULATOR" {
+		checkRemoteDir("total 0", "gcs", "sh", "-c", "ls -lh /data/altinity-qa-test/")
 	}
 }
 


### PR DESCRIPTION
Hi, I would like to propose to decouple gcs endpoint configuration with credentials.

Use case: We're connecting to gcs via private service connect:
https://cloud.google.com/vpc/docs/private-service-connect?authuser=1&_ga=2.220919888.-993337742.1685727395#supported-apis

The access control should stay the same regardless where the bucket is accessed from.

Let me know what do you think. Appreciate any feedback!