### PR TITLE
Fix wrong restoration of Materialized views with view name starting with digits

### DIFF
--- a/pkg/backup/table_pattern.go
+++ b/pkg/backup/table_pattern.go
@@ -295,7 +295,7 @@ func (b *Backuper) enrichTablePatternsByInnerDependencies(metadataPath string, t
 	return tablePatterns, nil
 }
 
-var queryRE = regexp.MustCompile(`(?m)^(CREATE|ATTACH) (TABLE|VIEW|LIVE VIEW|MATERIALIZED VIEW|DICTIONARY|FUNCTION) (\x60?)([^\s\x60.]*)(\x60?)\.([^\s\x60.]*)(?:( UUID '[^']+'))?(?:( TO )(\x60?)([^\s\x60.]*)(\x60?)(\.))?(?:(.+FROM )(\x60?)([^\s\x60.]*)(\x60?)(\.))?`)
+var queryRE = regexp.MustCompile(`(?m)^(CREATE|ATTACH) (TABLE|VIEW|LIVE VIEW|MATERIALIZED VIEW|DICTIONARY|FUNCTION) (\x60?)([^\s\x60.]*)(\x60?)\.\x60?([^\s\x60.]*)\x60?( UUID '[^']+')?(?:( TO )(\x60?)([^\s\x60.]*)(\x60?)(\.))?(?:(.+FROM )(\x60?)([^\s\x60.]*)(\x60?)(\.))?`)
 var createOrAttachRE = regexp.MustCompile(`(?m)^(CREATE|ATTACH)`)
 var uuidRE = regexp.MustCompile(`UUID '([a-f\d\-]+)'`)
 


### PR DESCRIPTION
Hi, If the materialized view names start with a digit and are enclosed in a backtick(`) during the view creation, the regex group capture for matching the TO database is missing. This further leads to the wrong restoration of materialized views, as the TO still points to the source database!

For example:- If we run the following restore command, 
`clickhouse-backup restore_remote --rm -m default:praveen <backup-name>`

The resulting materialized view will be the following. As you can see, the TO is still pointing to the source DB name, i.e., `default` instead of `praveen`)

```
CREATE MATERIALIZED VIEW praveen.`32da477b_0eb9_4aa6_bcbb_7f511649861e_v0_5_min_mv_shard` TO default.`32da477b_0eb9_4aa6_bcbb_7f511649861e_v0_5_min_mv_inner_shard` (

    `__created_at` AggregateFunction(max,
 DateTime),

    `__occurred_at` DateTime,

    `environment_id` UUID,

    `aggregation` String,

    `value` AggregateFunction(sum,
 Float64)
) AS
SELECT
    maxState(__created_at) AS __created_at,

    toStartOfFiveMinute(__occurred_at) AS __occurred_at,

    environment_id,

    aggregation,

    sumState(value) AS value
FROM praveen.`32da477b_0eb9_4aa6_bcbb_7f511649861e_v0_5_min_shard` GROUP BY
    environment_id,

    aggregation,

    __occurred_at
ORDER BY
    environment_id ASC,

    aggregation ASC,

    __occurred_at ASC;
```

The expected one:-

```
CREATE MATERIALIZED VIEW praveen.`32da477b_0eb9_4aa6_bcbb_7f511649861e_v0_5_min_mv_shard` TO praveen.`32da477b_0eb9_4aa6_bcbb_7f511649861e_v0_5_min_mv_inner_shard` (

    `__created_at` AggregateFunction(max,
 DateTime),

    `__occurred_at` DateTime,

    `environment_id` UUID,

    `aggregation` String,

    `value` AggregateFunction(sum,
 Float64)
) AS
SELECT
    maxState(__created_at) AS __created_at,

    toStartOfFiveMinute(__occurred_at) AS __occurred_at,

    environment_id,

    aggregation,

    sumState(value) AS value
FROM praveen.`32da477b_0eb9_4aa6_bcbb_7f511649861e_v0_5_min_shard` GROUP BY
    environment_id,

    aggregation,

    __occurred_at
ORDER BY
    environment_id ASC,

    aggregation ASC,

    __occurred_at ASC;
```