### PR TITLE
Added operation_id for async APIs

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -401,7 +401,7 @@ Create new backup: `curl -s localhost:7171/backup/create -X POST | jq .`
 - Optional query argument `schema` works the same as the `--schema` CLI argument (backup schema only).
 - Optional query argument `rbac` works the same as the `--rbac` CLI argument (backup RBAC).
 - Optional query argument `configs` works the same as the `--configs` CLI argument (backup configs).
-- Optional query argument `callback` allow pass callback URL which will call with POST with `application/json` with payload `{"status":"error|success","error":"not empty when error happens"}`.
+- Optional query argument `callback` allow pass callback URL which will call with POST with `application/json` with payload `{"status":"error|success","error":"not empty when error happens", "operation_id" : "<random_uuid>"}`.
 - Additional example: `curl -s 'localhost:7171/backup/create?table=default.billing&name=billing_test' -X POST`
 
 Note: this operation is asynchronous, so the API will return once the operation has started.
@@ -443,7 +443,7 @@ Upload backup to remote storage: `curl -s localhost:7171/backup/upload/<BACKUP_N
 - Optional query argument `partitions` works the same as the `--partitions value` CLI argument.
 - Optional query argument `schema` works the same as the `--schema` CLI argument (upload schema only).
 - Optional query argument `resumable` works the same as the `--resumable` CLI argument (save intermediate upload state and resume upload if data already exists on remote storage).
-- Optional query argument `callback` allow pass callback URL which will call with POST with `application/json` with payload `{"status":"error|success","error":"not empty when error happens"}`.
+- Optional query argument `callback` allow pass callback URL which will call with POST with `application/json` with payload `{"status":"error|success","error":"not empty when error happens", "operation_id" : "<random_uuid>"}`.
 
 Note: this operation is asynchronous, so the API will return once the operation has started.
 
@@ -464,7 +464,7 @@ Download backup from remote storage: `curl -s localhost:7171/backup/download/<BA
 - Optional query argument `partitions` works the same as the `--partitions value` CLI argument.
 - Optional query argument `schema` works the same as the `--schema` CLI argument (download schema only).
 - Optional query argument `resumable` works the same as the `--resumable` CLI argument (save intermediate download state and resume download if it already exists on local storage).
-- Optional query argument `callback` allow pass callback URL which will call with POST with `application/json` with payload `{"status":"error|success","error":"not empty when error happens"}`.
+- Optional query argument `callback` allow pass callback URL which will call with POST with `application/json` with payload `{"status":"error|success","error":"not empty when error happens", "operation_id" : "<random_uuid>"}`.
 
 Note: this operation is asynchronous, so the API will return once the operation has started.
 
@@ -482,7 +482,7 @@ Create schema and restore data from backup: `curl -s localhost:7171/backup/resto
 - Optional query argument `configs` works the same as the `--configs` CLI argument (restore configs).
 - Optional query argument `restore_database_mapping` works the same as the `--restore-database-mapping` CLI argument.
 - Optional query argument `restore_table_mapping` works the same as the `--restore-table-mapping` CLI argument.
-- Optional query argument `callback` allow pass callback URL which will call with POST with `application/json` with payload `{"status":"error|success","error":"not empty when error happens"}`.
+- Optional query argument `callback` allow pass callback URL which will call with POST with `application/json` with payload `{"status":"error|success","error":"not empty when error happens", "operation_id" : "<random_uuid>"}`.
 
 ### POST /backup/delete
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -36,6 +36,7 @@ import (
 	"github.com/Altinity/clickhouse-backup/v2/pkg/server/metrics"
 	"github.com/Altinity/clickhouse-backup/v2/pkg/status"
 	"github.com/Altinity/clickhouse-backup/v2/pkg/utils"
+	"github.com/google/uuid"
 )
 
 type APIServer struct {
@@ -874,6 +875,8 @@ func (api *APIServer) httpCreateHandler(w http.ResponseWriter, r *http.Request) 
 	checkPartsColumns := true
 	fullCommand := "create"
 	query := r.URL.Query()
+	operationId, _ := uuid.NewUUID()
+
 	if tp, exist := query["table"]; exist {
 		tablePattern = tp[0]
 		fullCommand = fmt.Sprintf("%s --tables=\"%s\"", fullCommand, tablePattern)
@@ -930,7 +933,7 @@ func (api *APIServer) httpCreateHandler(w http.ResponseWriter, r *http.Request) 
 		if err != nil {
 			log.Error().Msgf("API /backup/create error: %v", err)
 			status.Current.Stop(commandId, err)
-			api.errorCallback(context.Background(), err, callback)
+			api.errorCallback(context.Background(), err, operationId.String(), callback)
 			return
 		}
 		go func() {
@@ -940,16 +943,18 @@ func (api *APIServer) httpCreateHandler(w http.ResponseWriter, r *http.Request) 
 		}()
 
 		status.Current.Stop(commandId, nil)
-		api.successCallback(context.Background(), callback)
+		api.successCallback(context.Background(), operationId.String(), callback)
 	}()
 	api.sendJSONEachRow(w, http.StatusCreated, struct {
-		Status     string `json:"status"`
-		Operation  string `json:"operation"`
-		BackupName string `json:"backup_name"`
+		Status      string `json:"status"`
+		Operation   string `json:"operation"`
+		BackupName  string `json:"backup_name"`
+		OperationId string `json:"operation_id"`
 	}{
-		Status:     "acknowledged",
-		Operation:  "create",
-		BackupName: backupName,
+		Status:      "acknowledged",
+		Operation:   "create",
+		BackupName:  backupName,
+		OperationId: operationId.String(),
 	})
 }
 
@@ -1118,6 +1123,7 @@ func (api *APIServer) httpUploadHandler(w http.ResponseWriter, r *http.Request) 
 	schemaOnly := false
 	resume := false
 	fullCommand := "upload"
+	operationId, _ := uuid.NewUUID()
 
 	if _, exist := query["delete-source"]; exist {
 		deleteSource = true
@@ -1167,7 +1173,7 @@ func (api *APIServer) httpUploadHandler(w http.ResponseWriter, r *http.Request) 
 		if err != nil {
 			log.Error().Msgf("Upload error: %v", err)
 			status.Current.Stop(commandId, err)
-			api.errorCallback(context.Background(), err, callback)
+			api.errorCallback(context.Background(), err, operationId.String(), callback)
 			return
 		}
 		go func() {
@@ -1176,20 +1182,22 @@ func (api *APIServer) httpUploadHandler(w http.ResponseWriter, r *http.Request) 
 			}
 		}()
 		status.Current.Stop(commandId, nil)
-		api.successCallback(context.Background(), callback)
+		api.successCallback(context.Background(), operationId.String(), callback)
 	}()
 	api.sendJSONEachRow(w, http.StatusOK, struct {
-		Status     string `json:"status"`
-		Operation  string `json:"operation"`
-		BackupName string `json:"backup_name"`
-		BackupFrom string `json:"backup_from,omitempty"`
-		Diff       bool   `json:"diff"`
+		Status      string `json:"status"`
+		Operation   string `json:"operation"`
+		BackupName  string `json:"backup_name"`
+		BackupFrom  string `json:"backup_from,omitempty"`
+		Diff        bool   `json:"diff"`
+		OperationId string `json:"operation_id"`
 	}{
-		Status:     "acknowledged",
-		Operation:  "upload",
-		BackupName: name,
-		BackupFrom: diffFrom,
-		Diff:       diffFrom != "",
+		Status:      "acknowledged",
+		Operation:   "upload",
+		BackupName:  name,
+		BackupFrom:  diffFrom,
+		Diff:        diffFrom != "",
+		OperationId: operationId.String(),
 	})
 }
 
@@ -1219,6 +1227,7 @@ func (api *APIServer) httpRestoreHandler(w http.ResponseWriter, r *http.Request)
 	restoreRBAC := false
 	restoreConfigs := false
 	fullCommand := "restore"
+	operationId, _ := uuid.NewUUID()
 
 	query := r.URL.Query()
 	if tp, exist := query["table"]; exist {
@@ -1310,19 +1319,21 @@ func (api *APIServer) httpRestoreHandler(w http.ResponseWriter, r *http.Request)
 		status.Current.Stop(commandId, err)
 		if err != nil {
 			log.Error().Msgf("API /backup/restore error: %v", err)
-			api.errorCallback(context.Background(), err, callback)
+			api.errorCallback(context.Background(), err, operationId.String(), callback)
 			return
 		}
-		api.successCallback(context.Background(), callback)
+		api.successCallback(context.Background(), operationId.String(), callback)
 	}()
 	api.sendJSONEachRow(w, http.StatusOK, struct {
-		Status     string `json:"status"`
-		Operation  string `json:"operation"`
-		BackupName string `json:"backup_name"`
+		Status      string `json:"status"`
+		Operation   string `json:"operation"`
+		BackupName  string `json:"backup_name"`
+		OperationId string `json:"operation_id`
 	}{
-		Status:     "acknowledged",
-		Operation:  "restore",
-		BackupName: name,
+		Status:      "acknowledged",
+		Operation:   "restore",
+		BackupName:  name,
+		OperationId: operationId.String(),
 	})
 }
 
@@ -1346,6 +1357,7 @@ func (api *APIServer) httpDownloadHandler(w http.ResponseWriter, r *http.Request
 	schemaOnly := false
 	resume := false
 	fullCommand := "download"
+	operationId, _ := uuid.NewUUID()
 
 	if tp, exist := query["table"]; exist {
 		tablePattern = tp[0]
@@ -1381,7 +1393,7 @@ func (api *APIServer) httpDownloadHandler(w http.ResponseWriter, r *http.Request
 		if err != nil {
 			log.Error().Msgf("API /backup/download error: %v", err)
 			status.Current.Stop(commandId, err)
-			api.errorCallback(context.Background(), err, callback)
+			api.errorCallback(context.Background(), err, operationId.String(), callback)
 			return
 		}
 		go func() {
@@ -1390,16 +1402,18 @@ func (api *APIServer) httpDownloadHandler(w http.ResponseWriter, r *http.Request
 			}
 		}()
 		status.Current.Stop(commandId, nil)
-		api.successCallback(context.Background(), callback)
+		api.successCallback(context.Background(), operationId.String(), callback)
 	}()
 	api.sendJSONEachRow(w, http.StatusOK, struct {
-		Status     string `json:"status"`
-		Operation  string `json:"operation"`
-		BackupName string `json:"backup_name"`
+		Status      string `json:"status"`
+		Operation   string `json:"operation"`
+		BackupName  string `json:"backup_name"`
+		OperationId string `json:"operation_id"`
 	}{
-		Status:     "acknowledged",
-		Operation:  "download",
-		BackupName: name,
+		Status:      "acknowledged",
+		Operation:   "download",
+		BackupName:  name,
+		OperationId: operationId.String(),
 	})
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1328,7 +1328,7 @@ func (api *APIServer) httpRestoreHandler(w http.ResponseWriter, r *http.Request)
 		Status      string `json:"status"`
 		Operation   string `json:"operation"`
 		BackupName  string `json:"backup_name"`
-		OperationId string `json:"operation_id`
+		OperationId string `json:"operation_id"`
 	}{
 		Status:      "acknowledged",
 		Operation:   "restore",


### PR DESCRIPTION
Add operation_id (UUID) in callback, as well as create, restore, upload and download APIs. This helps when parallel operations are enabled and callbacks are to be sent at only one endpoint.