### PR TITLE
docs: update clickhouse-backup docker args example

### DIFF
--- a/Examples.md
+++ b/Examples.md
@@ -182,7 +182,7 @@ spec:
                       - clickhouse-server
                       - --config-file=/etc/clickhouse-server/config.xml
                  - name: clickhouse-backup
-                   image: altinity/clickhouse-backup:master
+                   image: altinity/clickhouse-backup:latest
                    imagePullPolicy: Always
                    args: ["server"]
                    env:

--- a/Examples.md
+++ b/Examples.md
@@ -184,10 +184,7 @@ spec:
                  - name: clickhouse-backup
                    image: altinity/clickhouse-backup:master
                    imagePullPolicy: Always
-                   command:
-                      - bash
-                      - -xc
-                      - "/bin/clickhouse-backup server"
+                   args: ["server"]
                    env:
                       - name: LOG_LEVEL
                         value: "debug"


### PR DESCRIPTION
Hi! I think one of the examples can be simplified.

The current command in the example for clickhouse-backup is
```
 command:
    - bash
    - -xc
    - "/bin/clickhouse-backup server"
```

And the Dockerfile ends with:
```
ENTRYPOINT ["/entrypoint.sh"]
CMD [ "/bin/clickhouse-backup", "--help" ]
```

This PR will update the docs to just pass `server` to the entrypoint script, since `bash` is unnecessary. The `-xc` flags could be useful for debugging, but I propose that using the args to specify `server` makes the example more clear.