### PR TITLE
fix: Use GCS storage backend when disk credentials are of type "gcs"

### DIFF
--- a/pkg/backup/restore.go
+++ b/pkg/backup/restore.go
@@ -1535,6 +1535,10 @@ func (b *Backuper) findObjectDiskPartRecursive(ctx context.Context, backup metad
 	}
 	var requiredTable *metadata.TableMetadata
 	requiredTable, err = b.downloadTableMetadataIfNotExists(ctx, requiredBackup.BackupName, metadata.TableTitle{Database: table.Database, Table: table.Table})
+	if err != nil {
+		return "", "", err
+	}
+
 	// @todo think about add check what if disk type could changed (should already restricted, cause upload seek part in the same disk name)
 	for requiredDiskName, parts := range requiredTable.Parts {
 		for _, requiredPart := range parts {


### PR DESCRIPTION
When restoring object disk in GCS and using JSON credentials the restore failed with error:

```
2024/09/20 16:32:50.270910 debug S3->CopyObject master-clickhouse-backup-disk/object_disks/my-clickhouse-cluster/0/{disk}/my-clickhouse-cluster-0-0-full-2024-09-18-11-00-01/s3_cache/brj/bvhkyblhkvucgsqxjiqrvqkctpymp -> master-clickhouse-disk/data/brj/bvhkyblhkvucgsqxjiqrvqkctpymp logger=S3
2024/09/20 16:32:50.271964  info clickhouse connection closed logger=clickhouse
2024/09/20 16:32:50.272000 error one of restoreDataRegular go-routine return error: can't restore object_disk server-side copy data parts 'rep.cs': one of downloadObjectDiskParts go-routine return error: object_disk.CopyObject error: operation error S3: CopyObject, get identity: get credentials: failed to refresh cached credentials, no EC2 IMDS role found, operation error ec2imds: GetMetadata, http response error StatusCode: 404, request to EC2 IMDS failed
```

As far as I understand, this happens due to the fact that in GCS case the restore tries to use the S3 client to perform the `CopyObject` operation with the authentication mechanisms native to AWS. Since I am providing GCP service account json in the `GCS_CREDENTIALS_JSON_ENCODED` env variable, this doesn't seem to work.

With this change the `restore` flow will use GCS backend when performing the `CopyObject` operation.