### PR TITLE
fix: fix slice init length

### DIFF
--- a/pkg/backup/backup_shard.go
+++ b/pkg/backup/backup_shard.go
@@ -71,7 +71,7 @@ type shardFunc func(md *tableReplicaMetadata) (bool, error)
 func shardFuncByName(name string) (shardFunc, error) {
 	chosen, ok := shardFuncRegistry[name]
 	if !ok {
-		validOptions := make([]string, len(shardFuncRegistry))
+		validOptions := make([]string, 0, len(shardFuncRegistry))
 		for k := range shardFuncRegistry {
 			if k == "" {
 				continue


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of   `len(shardFuncRegistry)`  rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW