### PR TITLE
Fix RBAC Backup Query: Change Type Filter to support "local directory" and "local_directory"

### DIFF
--- a/pkg/clickhouse/clickhouse.go
+++ b/pkg/clickhouse/clickhouse.go
@@ -1139,7 +1139,7 @@ func (ch *ClickHouse) GetAccessManagementPath(ctx context.Context, disks []Disk)
 	rows := make([]struct {
 		AccessPath string `ch:"access_path"`
 	}, 0)
-	if err := ch.SelectContext(ctx, &rows, "SELECT JSONExtractString(params,'path') AS access_path FROM system.user_directories WHERE type='local directory'"); err != nil || len(rows) == 0 {
+	if err := ch.SelectContext(ctx, &rows, "SELECT JSONExtractString(params,'path') AS access_path FROM system.user_directories WHERE type='local_directory'"); err != nil || len(rows) == 0 {
 		configFile, doc, err := ch.ParseXML(ctx, "config.xml")
 		if err != nil {
 			log.Warn().Msgf("can't parse config.xml from %s, error: %v", configFile, err)

--- a/pkg/clickhouse/clickhouse.go
+++ b/pkg/clickhouse/clickhouse.go
@@ -1139,7 +1139,7 @@ func (ch *ClickHouse) GetAccessManagementPath(ctx context.Context, disks []Disk)
 	rows := make([]struct {
 		AccessPath string `ch:"access_path"`
 	}, 0)
-	if err := ch.SelectContext(ctx, &rows, "SELECT JSONExtractString(params,'path') AS access_path FROM system.user_directories WHERE type='local_directory'"); err != nil || len(rows) == 0 {
+	if err := ch.SelectContext(ctx, &rows, "SELECT JSONExtractString(params,'path') AS access_path FROM system.user_directories WHERE type in ('local_directory','local directory')"); err != nil || len(rows) == 0 {
 		configFile, doc, err := ch.ParseXML(ctx, "config.xml")
 		if err != nil {
 			log.Warn().Msgf("can't parse config.xml from %s, error: %v", configFile, err)


### PR DESCRIPTION
# What's Changed in this PR?
This PR addresses an issue with RBAC backups where user accounts weren't being restored properly. I noticed that backups failed to restore users stored under the `local_directory` entry in the ClickHouse `system.user_directories` table. The root cause was that the code was filtering on the incorrect type value `local directory` (with a space) instead of the actual value `local_directory` (with an underscore). On my cluster when I query `SELECT * from system.user_directories` it returns the following:
![Screenshot 2025-04-10 at 15 30 47](https://github.com/user-attachments/assets/f6565895-c0de-4271-ac57-86a3f31e32ab)
This mismatch caused the query to return no results, leading to backup failures on certain filesystems such as ZFS.
## Changes
- Updated the SQL query in the backup code to filter on `type='local_directory'` instead of `type='local directory'`.
- This ensures the `JSONExtractString` function correctly extracts the access path from the `params` JSON field, returning the proper value (e.g., `/mnt/zfs0/clickhouse/access/`).