### PR TITLE
Fixes erroneous error when backup_to_keep_local=-1

### DIFF
--- a/pkg/backup/watch.go
+++ b/pkg/backup/watch.go
@@ -178,7 +178,7 @@ func (b *Backuper) Watch(watchInterval, fullInterval, watchBackupNameTemplate, t
 
 			}
 
-			if createRemoteErrCount > b.cfg.General.BackupsToKeepRemote || deleteLocalErrCount > b.cfg.General.BackupsToKeepLocal {
+			if createRemoteErrCount > b.cfg.General.BackupsToKeepRemote || deleteLocalErrCount > b.cfg.General.BackupsToKeepLocal && b.cfg.General.BackupsToKeepLocal >= 0 {
 				return fmt.Errorf("too many errors create_remote: %d, delete local: %d, during watch full_interval: %s, abort watching", createRemoteErrCount, deleteLocalErrCount, b.cfg.General.FullInterval)
 			}
 			if (createRemoteErr != nil || deleteLocalErr != nil) && time.Now().Sub(lastFullBackup) > b.cfg.General.FullDuration {


### PR DESCRIPTION
Even if the number of delete local errors is 0 the condition is still triggered since 0 > -1

Closes #1156 