### PR TITLE
Checking that the local backup hasn't already been deleted by the cre…

### DIFF
--- a/pkg/backup/watch.go
+++ b/pkg/backup/watch.go
@@ -124,7 +124,8 @@ func (b *Backuper) Watch(watchInterval, fullInterval, watchBackupNameTemplate, t
 				createRemoteErr, createRemoteErrCount = metrics.ExecuteWithMetrics("create_remote", createRemoteErrCount, func() error {
 					return b.CreateToRemote(backupName, deleteSource, "", diffFromRemote, tablePattern, partitions, skipProjections, schemaOnly, backupRBAC, false, backupConfigs, false, skipCheckPartsColumns, false, version, commandId)
 				})
-				if !deleteSource {
+				// If backups_to_keep_local=-1 then the local backup is deleted in the upload step when RemoveOldBackupsLocal is called
+				if !deleteSource && b.cfg.General.BackupsToKeepLocal >= 0 {
 					deleteLocalErr, deleteLocalErrCount = metrics.ExecuteWithMetrics("delete", deleteLocalErrCount, func() error {
 						return b.RemoveBackupLocal(ctx, backupName, nil)
 					})


### PR DESCRIPTION
If backups_to_keep_local=-1 then RemoveOldBackupsLocal will remove any local backups RemoveOldBackupsLocal is called on every call to Upload (so whenever CreateToRemote is called, so is RemoveOldBackupsLocal) This causes an issue when --watch-delete-source=false since Watch will also try to delete the new local backup after the CreateToRemote call finishes By adding a check that BackupsToKeepLocal is greater than zero we make sure that we do not get duplicate deletes which error out and cause Watch to abort erroneously

Closes #1157 