### PR TITLE
feat: add chunk size configuration for object storage uploads

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -153,6 +153,7 @@ type S3Config struct {
 	RequestPayer            string            `yaml:"request_payer" envconfig:"S3_REQUEST_PAYER"`
 	CheckSumAlgorithm       string            `yaml:"check_sum_algorithm" envconfig:"S3_CHECKSUM_ALGORITHM"`
 	RetryMode               string            `yaml:"retry_mode" envconfig:"S3_RETRY_MODE"`
+	ChunkSize               int64             `yaml:"chunk_size" envconfig:"S3_CHUNK_SIZE"`
 	Debug                   bool              `yaml:"debug" envconfig:"S3_DEBUG"`
 }
 
@@ -623,6 +624,7 @@ func DefaultConfig() *Config {
 			Concurrency:             int(downloadConcurrency + 1),
 			MaxPartsCount:           4000,
 			RetryMode:               string(aws.RetryModeStandard),
+			ChunkSize:               5 * 1024 * 1024,
 		},
 		GCS: GCSConfig{
 			CompressionLevel:  1,


### PR DESCRIPTION
## Introduce chunk size configuration for object storage uploads

### Background
We are backing up ClickHouse databases to MINIo object storage in a private cloud environment.

### Problem
When using the existing `max_parts_count` configuration, we encountered excessive load during backup operations. This caused resource contention issues and slowed down uploads, especially with larger backups.

### Solution
I added a new option to control chunk size during object storage uploads. By adjusting the chunk size, we can optimize resource usage and avoid spikes in network or disk load. This feature has been tested successfully in our environment.

### Request
I hope this chunk size control feature can be officially included in the project to provide better flexibility for MINIo and similar scenarios.

Please let me know if any changes are needed or if further testing is required. Thank you!

```bash
# Set the chunk_size to 10MB
# ClickHouse-Backup Console Log
2025-09-16 06:34:14.896 DBG .../clickhouse-backup/pkg/storage/s3.go:348 > S3 Upload PartSize: 10485760 bytes (10.00 MB)
...
2025-09-16 06:34:15.225 INF .../clickhouse-backup/pkg/storage/s3.go:49 > [s3:DEBUG] Request
PUT /zen-test/gage-10m/shadow/stackoverflow/votes/default_all_212_217_1.tar?partNumber=1&uploadId=ea0c55bd-bd84-4f62-8da3-db683a902e88&x-id=UploadPart HTTP/1.1
Host: s3.us-east-1.privatecloud-tecace.com
User-Agent: aws-sdk-go-v2/1.38.1 ua/2.1 os/linux lang/go#1.25.0 md/GOOS#linux md/GOARCH#amd64 api/s3#1.72.0 ft/s3-transfer m/E,G
Content-Length: 10485760
Accept-Encoding: identity
Amz-Sdk-Invocation-Id: 9b26ab65-8f4c-4df6-bf35-b6ad66d03092
Amz-Sdk-Request: attempt=1; max=3
Authorization: AWS4-HMAC-SHA256 Credential=.../20250916/us-east-1/s3/aws4_request, SignedHeaders=accept-encoding;amz-sdk-invocation-id;amz-sdk-request;content-length;content-type;host;x-amz-content-sha256;x-amz-date, Signature=...
Content-Type: application/octet-stream
Expect: 100-continue
X-Amz-Content-Sha256: UNSIGNED-PAYLOAD
X-Amz-Date: 20250916T063415Z
```
