### PR TITLE
S3 chunksize

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -265,6 +265,7 @@ s3:
   use_custom_storage_class: false  # S3_USE_CUSTOM_STORAGE_CLASS
   storage_class: STANDARD          # S3_STORAGE_CLASS, by default allow only from list https://github.com/aws/aws-sdk-go-v2/blob/main/service/s3/types/enums.go#L787-L799
   concurrency: 1                   # S3_CONCURRENCY
+  chunk_size: 0                    # S#_CHUNK_SIZE, default 0: remoteSize / max_part_count
   max_parts_count: 4000            # S3_MAX_PARTS_COUNT, number of parts for S3 multipart uploads and downloads
   allow_multipart_download: false  # S3_ALLOW_MULTIPART_DOWNLOAD, allow faster multipart download speed, but will require additional disk space, download_concurrency * part size in worst case
   checksum_algorithm: ""           # S3_CHECKSUM_ALGORITHM, use it when you use object lock which allow to avoid delete keys from bucket until some timeout after creation, use CRC32 as fastest

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -153,6 +153,7 @@ type S3Config struct {
 	RequestPayer            string            `yaml:"request_payer" envconfig:"S3_REQUEST_PAYER"`
 	CheckSumAlgorithm       string            `yaml:"check_sum_algorithm" envconfig:"S3_CHECKSUM_ALGORITHM"`
 	RetryMode               string            `yaml:"retry_mode" envconfig:"S3_RETRY_MODE"`
+	ChunkSize               int64             `yaml:"chunk_size" envconfig:"S3_CHUNK_SIZE"`
 	Debug                   bool              `yaml:"debug" envconfig:"S3_DEBUG"`
 }
 
@@ -623,6 +624,7 @@ func DefaultConfig() *Config {
 			Concurrency:             int(downloadConcurrency + 1),
 			MaxPartsCount:           4000,
 			RetryMode:               string(aws.RetryModeStandard),
+			ChunkSize:               5 * 1024 * 1024,
 		},
 		GCS: GCSConfig{
 			CompressionLevel:  1,

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -258,7 +258,7 @@ func (s *S3) GetFileReaderWithLocalPath(ctx context.Context, key, localPath stri
 		downloader.Concurrency = s.Concurrency
 		downloader.BufferProvider = s3manager.NewPooledBufferedWriterReadFromProvider(s.BufferSize)
 		var partSize int64
-		if s.Config.ChunkSize > 0 {
+		if s.Config.ChunkSize > 0 && (remoteSize+s.Config.ChunkSize-1)/s.Config.ChunkSize < 10000 {
 			// Use configured chunk size
 			partSize = s.Config.ChunkSize
 		} else {
@@ -335,8 +335,7 @@ func (s *S3) PutFileAbsolute(ctx context.Context, key string, r io.ReadCloser, l
 	uploader.Concurrency = s.Concurrency
 	uploader.BufferProvider = s3manager.NewBufferedReadSeekerWriteToPool(s.BufferSize)
 	var partSize int64
-	if s.Config.ChunkSize > 0 {
-		// Use configured chunk size
+	if s.Config.ChunkSize > 0 && (remoteSize+s.Config.ChunkSize-1)/s.Config.ChunkSize < 10000 {
 		partSize = s.Config.ChunkSize
 	} else {
 		partSize := localSize / s.Config.MaxPartsCount
@@ -549,7 +548,7 @@ func (s *S3) CopyObject(ctx context.Context, srcSize int64, srcBucket, srcKey, d
 
 	// Set the part size (128 MB minimum for CopyObject, or use configured chunk size)
 	var partSize int64
-	if s.Config.ChunkSize > 0 {
+	if s.Config.ChunkSize > 0 && (remoteSize+s.Config.ChunkSize-1)/s.Config.ChunkSize < 10000 {
 		partSize = s.Config.ChunkSize
 	} else {
 		partSize := srcSize / s.Config.MaxPartsCount


### PR DESCRIPTION
Background
We are backing up ClickHouse databases to MINIo object storage in a private cloud environment.

Problem
When using the existing max_parts_count configuration, we encountered excessive load during backup operations. This caused resource contention issues and slowed down uploads, especially with larger backups.

Solution
I added a new option to control chunk size during object storage uploads. By adjusting the chunk size, we can optimize resource usage and avoid spikes in network or disk load. This feature has been tested successfully in our environment.

Update
When the file size was divided based on chunk_size, it was modified not to exceed 10000.

Request
I hope this chunk size control feature can be officially included in the project to provide better flexibility for MINIo and similar scenarios.

Please let me know if any changes are needed or if further testing is required. Thank you!

