### PR TITLE
remove s3 debug from example and set log level to info

### DIFF
--- a/Examples.md
+++ b/Examples.md
@@ -241,7 +241,7 @@ spec:
               args: [ "server" ]
               env:
                 - name: LOG_LEVEL
-                  value: "debug"
+                  value: "info"
                 - name: ALLOW_EMPTY_BACKUPS
                   value: "true"
                 - name: API_LISTEN
@@ -273,8 +273,6 @@ spec:
                   value: "true"
                 # remove it for production S3
                 - name: S3_DISABLE_SSL
-                  value: "true"
-                - name: S3_DEBUG
                   value: "true"
                 # require to avoid double scraping clickhouse and clickhouse-backup containers
               ports:

--- a/Examples.md
+++ b/Examples.md
@@ -274,6 +274,8 @@ spec:
                 # remove it for production S3
                 - name: S3_DISABLE_SSL
                   value: "true"
+                - name: S3_DEBUG
+                  value: "false"
                 # require to avoid double scraping clickhouse and clickhouse-backup containers
               ports:
                 - name: backup-rest


### PR DESCRIPTION
This removes the setting in the k8s example config for setting the S3 log level to debug, and changes the LOG_LEVEL to info.

I found that if you actually deploy it with the settings in the example the S3 logging uses up quite a lot of resources and can even cause the system load average to go up on a live cluster.