### PR TITLE
fix S3 multipart operations to respect S3_MAX_PARTS_COUNT

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# v2.6.42
+BUG FIXES
+- fix S3 multipart operations (upload, download, copy) to respect `S3_MAX_PARTS_COUNT` instead of hardcoded 10000 value, allows S3-compatible backends with stricter limits
+
 # v2.6.41
 BUG FIXES
 - improve restore long RBAC which have length more 64k, fix [1305](https://github.com/Altinity/clickhouse-backup/issues/1305) 

--- a/pkg/backup/backuper.go
+++ b/pkg/backup/backuper.go
@@ -372,9 +372,9 @@ func (b *Backuper) getObjectDiskPath() (string, error) {
 		return b.cfg.FTP.ObjectDiskPath, nil
 	} else if b.cfg.General.RemoteStorage == "sftp" {
 		return b.cfg.SFTP.ObjectDiskPath, nil
-	} else {
-		return "", fmt.Errorf("cleanBackupObjectDisks: requesst object disks path but have unsupported remote_storage: %s", b.cfg.General.RemoteStorage)
 	}
+
+	return "", errors.WithStack(fmt.Errorf("cleanBackupObjectDisks: requesst object disks path but have unsupported remote_storage: %s", b.cfg.General.RemoteStorage))
 }
 
 func (b *Backuper) getTablesDiffFromLocal(ctx context.Context, diffFrom string, tablePattern string) (tablesForUploadFromDiff map[metadata.TableTitle]metadata.TableMetadata, err error) {

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -258,7 +258,7 @@ func (s *S3) GetFileReaderWithLocalPath(ctx context.Context, key, localPath stri
 		downloader.Concurrency = s.Concurrency
 		downloader.BufferProvider = s3manager.NewPooledBufferedWriterReadFromProvider(s.BufferSize)
 		var partSize int64
-		if s.Config.ChunkSize > 0 && (remoteSize+s.Config.ChunkSize-1)/s.Config.ChunkSize < 10000 {
+		if s.Config.ChunkSize > 0 && (remoteSize+s.Config.ChunkSize-1)/s.Config.ChunkSize < s.Config.MaxPartsCount {
 			// Use configured chunk size
 			partSize = s.Config.ChunkSize
 		} else {
@@ -334,7 +334,7 @@ func (s *S3) PutFileAbsolute(ctx context.Context, key string, r io.ReadCloser, l
 	uploader.Concurrency = s.Concurrency
 	uploader.BufferProvider = s3manager.NewBufferedReadSeekerWriteToPool(s.BufferSize)
 	var partSize int64
-	if s.Config.ChunkSize > 0 && (localSize+s.Config.ChunkSize-1)/s.Config.ChunkSize < 10000 {
+	if s.Config.ChunkSize > 0 && (localSize+s.Config.ChunkSize-1)/s.Config.ChunkSize < s.Config.MaxPartsCount {
 		partSize = s.Config.ChunkSize
 	} else {
 		partSize = localSize / s.Config.MaxPartsCount
@@ -546,7 +546,7 @@ func (s *S3) CopyObject(ctx context.Context, srcSize int64, srcBucket, srcKey, d
 
 	// Set the part size (128 MB minimum for CopyObject, or use configured chunk size)
 	var partSize int64
-	if s.Config.ChunkSize > 0 && (srcSize+s.Config.ChunkSize-1)/s.Config.ChunkSize < 10000 {
+	if s.Config.ChunkSize > 0 && (srcSize+s.Config.ChunkSize-1)/s.Config.ChunkSize < s.Config.MaxPartsCount {
 		partSize = s.Config.ChunkSize
 	} else {
 		partSize = srcSize / s.Config.MaxPartsCount


### PR DESCRIPTION
Hi there,

I'm using a s3 provider with a limit of 1000 parts per upload, unfortunately the operations use the hardcoded limit for AWS (10000) instead of using the configValue S3_MAX_PARTS_COUNT.
This pull request should fix that behavior.

Thanks,