### PR TITLE
fix: attach per-part checksum header on UploadPart for Object Lock buckets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ vendor/
 .aider*
 AGENTS.md
 CLAUDE.md
+GEMINI.md
 .qwen/
 .claude/
 .crush/

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -1,9 +1,12 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"net/http"
 	"os"
@@ -339,9 +342,6 @@ func (s *S3) PutFileAbsolute(ctx context.Context, key string, r io.ReadCloser, l
 	if s.Config.SSEKMSEncryptionContext != "" {
 		params.SSEKMSEncryptionContext = aws.String(s.Config.SSEKMSEncryptionContext)
 	}
-	uploader := s3manager.NewUploader(s.client)
-	uploader.Concurrency = s.Concurrency
-	uploader.BufferProvider = s3manager.NewBufferedReadSeekerWriteToPool(s.BufferSize)
 	var partSize int64
 	if s.Config.ChunkSize > 0 && (localSize+s.Config.ChunkSize-1)/s.Config.ChunkSize < s.Config.MaxPartsCount {
 		partSize = s.Config.ChunkSize
@@ -351,10 +351,101 @@ func (s *S3) PutFileAbsolute(ctx context.Context, key string, r io.ReadCloser, l
 			partSize += max(1, (localSize%s.Config.MaxPartsCount)/s.Config.MaxPartsCount)
 		}
 	}
-	uploader.PartSize = AdjustValueByRange(partSize, 5*1024*1024, 5*1024*1024*1024)
+	partSize = AdjustValueByRange(partSize, 5*1024*1024, 5*1024*1024*1024)
+
+	// s3manager.Uploader sends the part checksum as a trailer, which S3 Object Lock rejects on UploadPart. Fall back to manual multipart with per-part x-amz-checksum-crc32 header, fix https://github.com/Altinity/clickhouse-backup/issues/829
+	if s.Config.CheckSumAlgorithm == string(s3types.ChecksumAlgorithmCrc32) && localSize > partSize {
+		return s.putFileMultipartCRC32(ctx, &params, r, localSize, partSize)
+	}
+
+	uploader := s3manager.NewUploader(s.client)
+	uploader.Concurrency = s.Concurrency
+	uploader.BufferProvider = s3manager.NewBufferedReadSeekerWriteToPool(s.BufferSize)
+	uploader.PartSize = partSize
 
 	if _, err := uploader.Upload(ctx, &params); err != nil {
 		return errors.WithMessage(err, "S3 PutFileAbsolute Upload")
+	}
+	return nil
+}
+
+func (s *S3) putFileMultipartCRC32(ctx context.Context, putParams *s3.PutObjectInput, r io.Reader, localSize, partSize int64) error {
+	createParams := &s3.CreateMultipartUploadInput{
+		Bucket:       putParams.Bucket,
+		Key:          putParams.Key,
+		StorageClass: putParams.StorageClass,
+		ACL:          putParams.ACL,
+		Tagging:      putParams.Tagging,
+	}
+	s.enrichCreateMultipartUploadParams(createParams)
+
+	initResp, err := s.client.CreateMultipartUpload(ctx, createParams)
+	if err != nil {
+		return errors.WithMessage(err, "S3 putFileMultipartCRC32 CreateMultipartUpload")
+	}
+	uploadID := initResp.UploadId
+
+	abort := func(cause error) error {
+		abortParams := &s3.AbortMultipartUploadInput{
+			Bucket:   putParams.Bucket,
+			Key:      putParams.Key,
+			UploadId: uploadID,
+		}
+		if s.Config.RequestPayer != "" {
+			abortParams.RequestPayer = s3types.RequestPayer(s.Config.RequestPayer)
+		}
+		if _, abortErr := s.client.AbortMultipartUpload(context.Background(), abortParams); abortErr != nil {
+			return errors.Wrapf(cause, "aborting putFileMultipartCRC32 multipart upload: %v, original error was", abortErr)
+		}
+		return cause
+	}
+
+	buf := make([]byte, partSize)
+	parts := make([]s3types.CompletedPart, 0, (localSize+partSize-1)/partSize)
+	var partNumber int32 = 1
+	remaining := localSize
+	for remaining > 0 {
+		toRead := partSize
+		if remaining < toRead {
+			toRead = remaining
+		}
+		if _, readErr := io.ReadFull(r, buf[:toRead]); readErr != nil {
+			return abort(errors.Wrapf(readErr, "S3 putFileMultipartCRC32 read part=%d", partNumber))
+		}
+		h := crc32.NewIEEE()
+		h.Write(buf[:toRead])
+		uploadParams := &s3.UploadPartInput{
+			Bucket:            putParams.Bucket,
+			Key:               putParams.Key,
+			UploadId:          uploadID,
+			PartNumber:        aws.Int32(partNumber),
+			Body:              bytes.NewReader(buf[:toRead]),
+			ChecksumAlgorithm: s3types.ChecksumAlgorithmCrc32,
+			ChecksumCRC32:     aws.String(base64.StdEncoding.EncodeToString(h.Sum(nil))),
+		}
+		if s.Config.RequestPayer != "" {
+			uploadParams.RequestPayer = s3types.RequestPayer(s.Config.RequestPayer)
+		}
+		partResp, uploadErr := s.client.UploadPart(ctx, uploadParams)
+		if uploadErr != nil {
+			return abort(errors.Wrapf(uploadErr, "S3 putFileMultipartCRC32 UploadPart part=%d", partNumber))
+		}
+		parts = append(parts, s3types.CompletedPart{
+			ETag:          partResp.ETag,
+			PartNumber:    aws.Int32(partNumber),
+			ChecksumCRC32: partResp.ChecksumCRC32,
+		})
+		partNumber++
+		remaining -= toRead
+	}
+
+	if _, completeErr := s.client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{
+		Bucket:          putParams.Bucket,
+		Key:             putParams.Key,
+		UploadId:        uploadID,
+		MultipartUpload: &s3types.CompletedMultipartUpload{Parts: parts},
+	}); completeErr != nil {
+		return abort(errors.WithMessage(completeErr, "S3 putFileMultipartCRC32 CompleteMultipartUpload"))
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes upload failures against S3 buckets with Object Lock enabled.

## Problem

With `s3.checksum_algorithm: CRC32` set in config, single `PutObject` / `CopyObject` uploads succeed against Object Lock buckets (that path was fixed in #829). Large file uploads still fail during multipart:

```
operation error S3: UploadPart, https response error StatusCode: 400,
api error InvalidRequest: Content-MD5 OR x-amz-checksum-* HTTP header
is required for Put Part requests with Object Lock parameters
```

`s3manager.Uploader` sends the per-part checksum as an HTTP trailer (via aws-chunked encoding). Object Lock rejects trailer-based checksums on `UploadPart` — it requires the checksum as a request header.

## Fix

When `CheckSumAlgorithm == CRC32` and the file is large enough to trigger multipart, `PutFileAbsolute` dispatches to a manual multipart path (`putFileMultipartCRC32`) that:

1. Calls `CreateMultipartUpload` (existing enrich helper used, so tags / SSE / ACL preserved).
2. Reads each part into a buffer, computes CRC32 (IEEE), base64-encodes it.
3. Calls `UploadPart` with `ChecksumAlgorithm: CRC32` and `ChecksumCRC32: <base64>` — the SDK serialises this as the `x-amz-checksum-crc32` request header, which Object Lock accepts.
4. Aborts on any failure; completes via `CompleteMultipartUpload` on success.

For all other cases (no checksum configured, non-CRC32 algo, file below part size), the original `s3manager.Uploader` path is unchanged.

## Scope

- Only activates when the operator opts in via `checksum_algorithm: CRC32`, so existing deployments are unaffected.
- Does not touch `CopyObject` (multipart copy) — `UploadPartCopyInput` has no `ChecksumAlgorithm` field; server-side copy derives integrity from the source object and is not covered by this failure mode.
- Sequential upload loop; concurrency matches `s3manager.Uploader` behaviour only in the dispatched case. Can be parallelised as a follow-up if needed.

## Verification

Tested against a real AWS S3 bucket in `ca-central-1` with Object Lock Compliance mode (30-day default retention). Before the patch: every multipart upload fails with the InvalidRequest error above. After: uploads complete and objects land under the default retention.

## Related

- #829 — original Object Lock support (PutObject / CopyObject). This PR extends to UploadPart.
- #1324 / #1329 — Content-MD5 on DeleteObjects (related but separate code path).