### PR TITLE
fix: restore --rbac should not error when backup has no RBAC access dir

### DIFF
--- a/pkg/backup/restore.go
+++ b/pkg/backup/restore.go
@@ -616,6 +616,10 @@ func (b *Backuper) restoreRBAC(ctx context.Context, backupName string, disks []c
 
 func (b *Backuper) restoreRBACResolveAllConflicts(ctx context.Context, backupName string, accessPath string, version int, k *keeper.Keeper, replicatedUserDirectories []clickhouse.UserDirectory, dropExists bool) error {
 	backupAccessPath := path.Join(b.DefaultDataPath, "backup", backupName, "access")
+	if _, statErr := os.Stat(backupAccessPath); os.IsNotExist(statErr) {
+		log.Debug().Msgf("backup access path %s doesn't exist, skip RBAC restore", backupAccessPath)
+		return nil
+	}
 
 	walkErr := filepath.Walk(backupAccessPath, func(fPath string, fInfo fs.FileInfo, err error) error {
 		if err != nil {

--- a/pkg/backup/restore.go
+++ b/pkg/backup/restore.go
@@ -931,6 +931,10 @@ func (b *Backuper) restoreRBACReplicated(backupName string, backupPrefixDir stri
 	info, err := os.Stat(srcBackupDir)
 	if err != nil {
 		log.Warn().Msgf("stat: %s error: %v", srcBackupDir, err)
+		// keep the not-exist error unwrapped so callers can detect it via os.IsNotExist
+		if os.IsNotExist(err) {
+			return err
+		}
 		return errors.Wrap(err, "stat backup dir")
 	}
 
@@ -1424,6 +1428,10 @@ func (b *Backuper) restoreBackupRelatedDir(backupName, backupPrefixDir, destinat
 	info, err := os.Stat(srcBackupDir)
 	if err != nil {
 		log.Warn().Msgf("stat: %s error: %v", srcBackupDir, err)
+		// keep the not-exist error unwrapped so callers can detect it via os.IsNotExist
+		if os.IsNotExist(err) {
+			return err
+		}
 		return errors.Wrap(err, "stat backup dir")
 	}
 	existsFiles, _ := os.ReadDir(destinationDir)

--- a/pkg/backup/restore_test.go
+++ b/pkg/backup/restore_test.go
@@ -1,10 +1,12 @@
 package backup
 
 import (
+	"context"
 	"fmt"
+	"testing"
+
 	"github.com/Altinity/clickhouse-backup/v2/pkg/config"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestDetectRBACObject(t *testing.T) {
@@ -220,4 +222,12 @@ func TestChangeTablePatternFromRestoreMapping(t *testing.T) {
 			assert.Equal(t, tc.expected, result)
 		})
 	}
+}
+
+func TestRestoreRBACResolveAllConflictsMissingAccessDir(t *testing.T) {
+	b := &Backuper{DefaultDataPath: t.TempDir()}
+
+	err := b.restoreRBACResolveAllConflicts(context.Background(), "missing-backup", t.TempDir(), 0, nil, nil, false)
+
+	assert.NoError(t, err)
 }

--- a/pkg/backup/restore_test.go
+++ b/pkg/backup/restore_test.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/Altinity/clickhouse-backup/v2/pkg/config"
@@ -230,4 +231,15 @@ func TestRestoreRBACResolveAllConflictsMissingAccessDir(t *testing.T) {
 	err := b.restoreRBACResolveAllConflicts(context.Background(), "missing-backup", t.TempDir(), 0, nil, nil, false)
 
 	assert.NoError(t, err)
+}
+
+// restoreBackupRelatedDir must surface a missing source dir as an os.IsNotExist-recognizable
+// error so restoreRBAC's `os.IsNotExist(err)` guards can skip RBAC restore gracefully (issue #1432).
+func TestRestoreBackupRelatedDirMissingDirIsNotExist(t *testing.T) {
+	b := &Backuper{DefaultDataPath: t.TempDir()}
+
+	err := b.restoreBackupRelatedDir("missing-backup", "access", t.TempDir(), nil, []string{"*.jsonl"})
+
+	assert.Error(t, err)
+	assert.True(t, os.IsNotExist(err), "expected os.IsNotExist to match the returned error, got: %v", err)
 }


### PR DESCRIPTION
## Summary

Makes `restore --rbac` a graceful no-op when a backup contains no RBAC objects, matching the existing behavior of `download --rbac`. Previously, restoring such a backup failed with `restoreRBAC: restoreRBACResolveAllConflicts: walk backup access path: ... lstat .../access: no such file or directory`.

## Why this matters

fix #1432, `create_remote --rbac` on a cluster with no RBAC objects succeeds silently (`done createBackupRBAC, size=0B`), and `download --rbac` of that backup tolerates the missing `access` dir. But `restore --rbac` of the same backup errors out. This is an inconsistent, surprising failure for a perfectly valid backup.

The root cause is error-identity stripping: `restoreRBACResolveAllConflicts` runs `filepath.Walk` on `<DefaultDataPath>/backup/<name>/access`. When that dir is absent, the walk callback wraps the `*os.PathError` via `errors.Wrap(...)`, so the function's tail guard `os.IsNotExist(walkErr)` no longer matches and the error propagates. The same pattern affects `restoreBackupRelatedDir` (and `restoreRBACReplicated`), whose `os.Stat` ENOENT was also wrapped before reaching the caller's `os.IsNotExist(err)` guards in `restoreRBAC`.

## Changes

- `pkg/backup/restore.go`
  - `restoreRBACResolveAllConflicts`: add a narrow early return when `os.Stat(backupAccessPath)` reports the dir does not exist (log a debug line, return nil). Only the not-exist case is swallowed; the existing `os.IsNotExist(walkErr)` tail guard is kept as defense-in-depth.
  - `restoreBackupRelatedDir` and `restoreRBACReplicated`: when the source dir does not exist, return the unwrapped `os.Stat` error so the callers' existing `os.IsNotExist(err)` guards in `restoreRBAC` can detect it and skip RBAC restore. Non-not-exist stat errors are still wrapped as before.

## Testing

Added unit tests in `pkg/backup/restore_test.go` (no running ClickHouse required):

- `TestRestoreRBACResolveAllConflictsMissingAccessDir`: with `&Backuper{DefaultDataPath: t.TempDir()}` and no `access` dir, `restoreRBACResolveAllConflicts` returns nil.
- `TestRestoreBackupRelatedDirMissingDirIsNotExist`: a missing source dir yields an error for which `os.IsNotExist` is true, ensuring `restoreRBAC`'s graceful-skip guards keep working.

```
gofmt -l pkg/backup/restore.go pkg/backup/restore_test.go   # clean
go vet ./pkg/backup/...                                      # ok
go build ./...                                               # ok
go test ./pkg/backup/ -run 'RBAC|RestoreBackupRelatedDir' -count=1   # pass
```

Fixes #1432
