### PR TITLE
fix panic when system.backups query returns empty result on multi-node clusters

### DIFF
--- a/pkg/backup/create.go
+++ b/pkg/backup/create.go
@@ -526,7 +526,7 @@ func (b *Backuper) createBackupEmbedded(ctx context.Context, backupName, baseBac
 					if sizeErr := b.ch.SelectContext(ctx, &systemBackupResult, backupSizeSQL); sizeErr != nil {
 						return errors.Wrap(sizeErr, "system.backups query")
 					}
-					if len(systemBackupResult) == 0 && len(systemBackupResult) > 1 {
+					if len(systemBackupResult) != 1 {
 						return errors.Errorf("wrong system.backup results: %v", systemBackupResult)
 					}
 					backupDataSize = append(backupDataSize, clickhouse.BackupDataSize{Size: systemBackupResult[0].CompressedSize})


### PR DESCRIPTION
Fixes #1488. The guard at pkg/backup/create.go:529 checked `len(systemBackupResult) == 0 && len(systemBackupResult) > 1`, which can never be true, so an empty result from `system.backups` (load balancer routing the SELECT to a different replica than the BACKUP, as on ClickHouse Cloud) fell through to `systemBackupResult[0]` and panicked. Changed the condition to `len(systemBackupResult) != 1` so it returns the error the guard was already written to produce.
