### PR TITLE
Write machine-readable list output to os.Stdout in a single write

### DIFF
--- a/pkg/backup/backuper.go
+++ b/pkg/backup/backuper.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/binary"
 	"fmt"
 	"net/url"
@@ -626,6 +627,10 @@ func (b *Backuper) GetLocalDataSize(ctx context.Context) (float64, error) {
 		defer b.ch.Close()
 	}
 	err := b.ch.SelectSingleRow(ctx, &localDataSize, "SELECT value FROM system.asynchronous_metrics WHERE metric='TotalBytesOfMergeTreeTables'")
+	// TotalBytesOfMergeTreeTables present only in 21.1+, look https://github.com/ClickHouse/ClickHouse/pull/17639
+	if err != nil && errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
 	return localDataSize, err
 }
 

--- a/pkg/backup/list.go
+++ b/pkg/backup/list.go
@@ -81,7 +81,9 @@ func (b *Backuper) List(what, ptype, format string) error {
 }
 
 func (b *Backuper) PrintBackup(backupInfos []BackupInfo, format string) error {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', tabwriter.DiscardEmptyColumns)
+	// machine-readable formats write to os.Stdout in one Write. tabwriter emits the payload and its
+	// terminating newline separately, so a zerolog line on stderr can splice itself in between when
+	// both streams are merged (`docker exec`): `...}]2026-01-01 00:00:00 INF ...`.
 	switch format {
 	case "json":
 		bytes, err := json.Marshal(backupInfos)
@@ -89,7 +91,7 @@ func (b *Backuper) PrintBackup(backupInfos []BackupInfo, format string) error {
 			log.Error().Msgf("json.Marshal return error: %v", err)
 			return errors.Wrap(err, "PrintBackup json.Marshal")
 		}
-		if _, err := fmt.Fprintln(w, string(bytes)); err != nil {
+		if _, err := fmt.Fprintln(os.Stdout, string(bytes)); err != nil {
 			log.Error().Msgf("fmt.Fprintf write %d bytes return error: %v", bytes, err)
 			return errors.Wrap(err, "PrintBackup json Fprintln")
 		}
@@ -100,7 +102,7 @@ func (b *Backuper) PrintBackup(backupInfos []BackupInfo, format string) error {
 			log.Error().Msgf("yaml.Marshal return error: %v", err)
 			return errors.Wrap(err, "PrintBackup yaml.Marshal")
 		}
-		if _, err := fmt.Fprintln(w, string(bytes)); err != nil {
+		if _, err := fmt.Fprintln(os.Stdout, string(bytes)); err != nil {
 			log.Error().Msgf("fmt.Fprintf write %d bytes return error: %v", bytes, err)
 			return errors.Wrap(err, "PrintBackup yaml Fprintln")
 		}
@@ -112,7 +114,7 @@ func (b *Backuper) PrintBackup(backupInfos []BackupInfo, format string) error {
 			log.Error().Msgf("gocsv.MarshalString return error: %v", err)
 			return errors.Wrap(err, "PrintBackup csv MarshalString")
 		}
-		if _, err := fmt.Fprintln(w, csvString); err != nil {
+		if _, err := fmt.Fprintln(os.Stdout, csvString); err != nil {
 			log.Error().Msgf("fmt.Fprintf write %d bytes return error: %v", len(csvString), err)
 			return errors.Wrap(err, "PrintBackup csv Fprintln")
 		}
@@ -128,12 +130,13 @@ func (b *Backuper) PrintBackup(backupInfos []BackupInfo, format string) error {
 			log.Error().Msgf("gocsv.MarshalString return error: %v", err)
 			return errors.Wrap(err, "PrintBackup tsv MarshalString")
 		}
-		if _, err := fmt.Fprintln(w, csvString); err != nil {
+		if _, err := fmt.Fprintln(os.Stdout, csvString); err != nil {
 			log.Error().Msgf("fmt.Fprintf write %d bytes return error: %v", len(csvString), err)
 			return errors.Wrap(err, "PrintBackup tsv Fprintln")
 		}
 		return nil
 	case "text", "":
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', tabwriter.DiscardEmptyColumns)
 		for _, backup := range backupInfos {
 			creationDate := backup.CreationDate.In(time.Local).Format("2006-01-02 15:04:05")
 			if bytes, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", backup.BackupName, creationDate, backup.Type, backup.RequiredBackup, backup.Size, backup.Description); err != nil {

--- a/test/integration/watchScheduleServerMetrics_test.go
+++ b/test/integration/watchScheduleServerMetrics_test.go
@@ -18,6 +18,7 @@ func TestWatchScheduleServerMetrics(t *testing.T) {
 	env, r := NewTestEnvironment(t)
 	defer env.Cleanup(t, r)
 	env.connectWithWait(t, r, 0*time.Second, 1*time.Second, 1*time.Minute)
+	env.InstallDebIfNotExists(r, "clickhouse-backup", "ca-certificates", "curl")
 
 	dbName := "test_watch_schedule_metrics"
 	prefix := "sched1502"
@@ -85,7 +86,7 @@ func TestWatchScheduleServerMetrics(t *testing.T) {
 	for time.Now().Before(metricsDeadline) {
 		remoteNames = listRemote()
 		expected = fmt.Sprintf("%d", len(remoteNames))
-		out, err := env.DockerExecOut("clickhouse-backup", "wget", "-qO-", "http://localhost:7171/metrics")
+		out, err := env.DockerExecOut("clickhouse-backup", "curl", "-sSL", "http://localhost:7171/metrics")
 		r.NoError(err)
 		if m := metricRE.FindStringSubmatch(out); m != nil {
 			metricValue = m[1]


### PR DESCRIPTION
PrintBackup routed every format through a tabwriter over os.Stdout. tabwriter auto-flushes lines that contain no tabs, but emits the payload and its terminating newline as two separate Write calls. Since zerolog logs to stderr, a log line can land between them whenever both streams are merged - e.g. `docker exec`, where the daemon reads the container's stdout and stderr from separate pipes with no ordering guarantee. The result is a spliced line, `...}]2026-08-11 18:29:25 INF ...`, which made `list remote --format=json` unparseable and flaked TestRebaseFTP with "invalid character '2' after top-level value".

json/yaml/csv/tsv now write straight to os.Stdout in one Fprintln, so the payload and its newline reach the pipe as a single write. This also removes an inconsistency: those branches never called w.Flush() and worked only by way of tabwriter's implicit single-cell flush. tabwriter stays in the "text" branch, the only one that needs column alignment.